### PR TITLE
Change netzkarte baselayer for backward compatibility with old wkp

### DIFF
--- a/src/config/layers.js
+++ b/src/config/layers.js
@@ -61,7 +61,7 @@ const resolutions = [
 ];
 
 export const netzkarteLayer = new TrafimageMapboxLayer({
-  name: 'ch.sbb.netzkarte',
+  name: 'ch.sbb.netzkarte.relief',
   copyright: '© OpenStreetMap contributors, OpenMapTiles, imagico, SBB/CFF/FFS',
   visible: true,
   isQueryable: false,
@@ -455,7 +455,7 @@ export const netzkarteShowcasesLight = new TrafimageMapboxLayer({
 });
 
 export const netzkarteShowcasesNetzkarte = new TrafimageMapboxLayer({
-  name: 'ch.sbb.netzkarte',
+  name: 'ch.sbb.netzkarte.relief',
   copyright: '© OpenStreetMap contributors, OpenMapTiles, imagico, SBB/CFF/FFS',
   visible: true,
   isQueryable: false,

--- a/src/examples/Punctuality/layers.js
+++ b/src/examples/Punctuality/layers.js
@@ -36,7 +36,7 @@ const resolutions = [
 ];
 
 export const netzkarteLayer = new TrafimageMapboxLayer({
-  name: 'ch.sbb.netzkarte',
+  name: 'ch.sbb.netzkarte.relief',
   copyright: '© OpenStreetMap contributors, OpenMapTiles, imagico, SBB/CFF/FFS',
   visible: true,
   isQueryable: false,

--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -85,7 +85,7 @@
   "ch.sbb.netzkarte.luftbild.group": "Netzkarte Luftbild",
   "ch.sbb.netzkarte.night": "Nachtmodus",
   "ch.sbb.netzkarte.night-desc": "Die dunkle Version der Netzkarte Personenverkehr könnte zum Beispiel für die Darstellung eines Nachtnetzes eingesetzt werden.",
-  "ch.sbb.netzkarte.relief": "Netzkarte Relief",
+  "ch.sbb.netzkarte.relief": "Netzkarte Personenverkehr",
   "ch.sbb.netzkarte.stationen": "Bahnhöfe",
   "ch.sbb.netzkarte.tarifverbunde": "Tarifverbunde",
   "ch.sbb.netzkarte.tarifverbunde-desc": "Die Verbund-Landschaft der Schweiz. Finden Sie das für Sie passende Pendler- und Freizeitabo im Tarifverbund Ihrer Region.",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -90,7 +90,7 @@
   "ch.sbb.netzkarte.luftbild": "Network map (Aerial)",
   "ch.sbb.netzkarte.night": "Swiss public transport network map (night)",
   "ch.sbb.netzkarte.night-desc": "The dark version of the Network map passenger Traffic could be used to display a nighttime network, for example.",
-  "ch.sbb.netzkarte.relief": "Network map (Relief)",
+  "ch.sbb.netzkarte.relief": "Network map passenger Traffic",
   "ch.sbb.netzkarte.stationen": "Stations",
   "ch.sbb.netzkarte.tarifverbunde": "Fare networks",
   "ch.sbb.netzkarte.tarifverbunde-desc": "Switzerland’s network landscape. Find the right travelcard for you for commuting or leisure from your region’s fare network.",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -102,7 +102,7 @@
   "ch.sbb.netzkarte.luftbild": "Carte du réseau (Vue aérienne)",
   "ch.sbb.netzkarte.night": "Carte du réseau des TP suisses (nuit)",
   "ch.sbb.netzkarte.night-desc": "La version foncée de la carte de réseau trafic voyageurs peut être utilisée pour afficher un réseau de nuit par exemple.",
-  "ch.sbb.netzkarte.relief": "Carte du réseau (Relief)",
+  "ch.sbb.netzkarte.relief": "Carte de réseau trafic voyageurs",
   "ch.sbb.netzkarte.stationen": "Gares",
   "ch.sbb.netzkarte.tarifverbunde": "Communauté tarifaire",
   "ch.sbb.netzkarte.tarifverbunde-desc": "Les communautés tarifaires en Suisse: trouvez l’abonnement pendulaire et/ou loisirs qui vous convient dans la communauté tarifaire de votre région.",

--- a/src/lang/it.json
+++ b/src/lang/it.json
@@ -102,7 +102,7 @@
   "ch.sbb.netzkarte.luftbild": "Carta della rete (Veduta aerea)",
   "ch.sbb.netzkarte.night": "Carta di rete dei trasporti pubblici svizzeri (notte)",
   "ch.sbb.netzkarte.night-desc": "La versione a bassa luminosità della carta di rete traffico viaggiatori può essere impiegata, ad esempio, per la rappresentazione di una rete notturna.",
-  "ch.sbb.netzkarte.relief": "Carta della rete (Rilievo)",
+  "ch.sbb.netzkarte.relief": "Carta di rete traffico viaggiatori",
   "ch.sbb.netzkarte.stationen": "Stazioni",
   "ch.sbb.netzkarte.tarifverbunde": "Comunità tariffaria",
   "ch.sbb.netzkarte.tarifverbunde-desc": "La cartina delle comunità tariffarie svizzere. Cercate l’abbonamento per pendolari o per il tempo libero più adatto a voi nella comunità tariffaria della vostra regione.",


### PR DESCRIPTION
Similar to https://github.com/geops/trafimage-maps/pull/431, but not necessary as the netzkarte is the default baselayer