### PR TITLE
Netzkarte popup / Mouse position: Format coordinates...

### DIFF
--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -7,22 +7,13 @@ import Copyright from 'react-spatial/components/Copyright';
 import Select from '@geops/react-ui/components/Select';
 import MousePosition from 'react-spatial/components/MousePosition';
 import ActionLink from '@geops/react-ui/components/ActionLink';
+import coordinateHelper from '../../utils/coordinateHelper';
 import {
   setLanguage,
   setProjection,
   setDialogVisible,
 } from '../../model/app/actions';
 import './Footer.scss';
-
-const numberFormat = coords => {
-  const coordStr = coords.map(num =>
-    Math.round(num)
-      .toString()
-      .replace(/\B(?=(\d{3})+(?!\d))/g, "'"),
-  );
-
-  return coordStr;
-};
 
 const Footer = () => {
   const dispatch = useDispatch();
@@ -36,22 +27,22 @@ const Footer = () => {
     {
       label: 'CH1093 / LV03',
       value: 'EPSG:21781',
-      format: c => `${t('Koordinaten')}: ${numberFormat(c)}`,
+      format: c => `${t('Koordinaten')}: ${coordinateHelper.meterFormat(c)}`,
     },
     {
       label: 'CH1093+ / LV95',
       value: 'EPSG:2056',
-      format: c => `${t('Koordinaten')}: ${numberFormat(c)}`,
+      format: c => `${t('Koordinaten')}: ${coordinateHelper.meterFormat(c)}`,
     },
     {
       label: 'Web Mercator',
       value: 'EPSG:3857',
-      format: c => `${t('Koordinaten')}: ${numberFormat(c)}`,
+      format: c => `${t('Koordinaten')}: ${coordinateHelper.meterFormat(c)}`,
     },
     {
       label: 'WGS 84',
       value: 'EPSG:4326',
-      format: c => `${t('Koordinaten')}: ${c[0].toFixed(5)},${c[1].toFixed(5)}`,
+      format: c => `${t('Koordinaten')}: ${coordinateHelper.wgs84Format(c)}`,
     },
   ];
 

--- a/src/popups/NetzkartePopup/NetzkartePopup.js
+++ b/src/popups/NetzkartePopup/NetzkartePopup.js
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next';
 import { transform as transformCoords } from 'ol/proj';
 import { setClickedFeatureInfo } from '../../model/app/actions';
 import BahnhofplanPopup from '../BahnhofplanPopup';
+import coordinateHelper from '../../utils/coordinateHelper';
 
 const propTypes = {
   feature: PropTypes.instanceOf(Feature).isRequired,
@@ -141,12 +142,10 @@ function NetzkartePopup({ feature }) {
           projection.value,
         );
 
-  const formatedCoords = coordinates.map(input => {
-    const coord = Math.round(parseFloat(input) * 10 ** 4) / 10 ** 4;
-    const parts = coord.toString().split('.');
-    parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, "'");
-    return parts.join();
-  });
+  const formatedCoords =
+    projection.value === 'EPSG:4326'
+      ? coordinateHelper.wgs84Format(coordinates, ',')
+      : coordinateHelper.meterFormat(coordinates);
 
   const coordinatesWrapper = (
     <div>

--- a/src/utils/coordinateHelper.js
+++ b/src/utils/coordinateHelper.js
@@ -1,0 +1,15 @@
+function meterFormat(coords) {
+  const coordStr = coords.map(num =>
+    Math.round(num)
+      .toString()
+      .replace(/\B(?=(\d{3})+(?!\d))/g, "'"),
+  );
+
+  return coordStr;
+}
+
+function wgs84Format(coords, decimalSep = '.') {
+  return coords.map(num => num.toFixed(5).replace('.', decimalSep));
+}
+
+export default { meterFormat, wgs84Format };

--- a/src/utils/coordinateHelper.js
+++ b/src/utils/coordinateHelper.js
@@ -1,11 +1,9 @@
 function meterFormat(coords) {
-  const coordStr = coords.map(num =>
+  return coords.map(num =>
     Math.round(num)
       .toString()
       .replace(/\B(?=(\d{3})+(?!\d))/g, "'"),
   );
-
-  return coordStr;
 }
 
 function wgs84Format(coords, decimalSep = '.') {

--- a/src/utils/coordinateHelper.test.js
+++ b/src/utils/coordinateHelper.test.js
@@ -1,0 +1,19 @@
+import 'jest-canvas-mock';
+import coordinateHelper from './coordinateHelper';
+
+describe('coordinateHelper', () => {
+  test('should format coordinates correcly.', () => {
+    expect(
+      coordinateHelper.wgs84Format([8.298163986976597, 47.041177354357444]),
+    ).toEqual(['8.29816', '47.04118']);
+    expect(
+      coordinateHelper.wgs84Format(
+        [8.298163986976597, 47.041177354357444],
+        ',',
+      ),
+    ).toEqual(['8,29816', '47,04118']);
+    expect(
+      coordinateHelper.meterFormat([929977.0073545576, 5948635.427925528]),
+    ).toEqual(["929'977", "5'948'635"]);
+  });
+});


### PR DESCRIPTION
- Central formatting functions
- Meter coordinates without decimal places (especially in Netzkarte popup)
- Unify decimal places for WGS84 (now 5 instead of 4 in Netzkarte popup)