### PR TITLE
mapbox-gl update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trafimage-maps",
-  "version": "1.0.7-beta.75",
+  "version": "1.0.7-beta.71",
   "main": "build/bundle.js",
   "proxy": "http://127.0.0.1:8000",
   "dependencies": {
@@ -19,7 +19,7 @@
     "i18next-xhr-backend": "^3.2.2",
     "jsts": "^2.1.0",
     "lodash": "^4.17.11",
-    "mapbox-gl": "^1.8.0",
+    "mapbox-gl": "^1.8.1",
     "node-sass": "^4.13.1",
     "ol": "6.1.1",
     "package.json": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trafimage-maps",
-  "version": "1.0.7-beta.71",
+  "version": "1.0.7-beta.75",
   "main": "build/bundle.js",
   "proxy": "http://127.0.0.1:8000",
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10961,10 +10961,10 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-mapbox-gl@^1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/mapbox-gl/-/mapbox-gl-1.8.0.tgz#77f8350c1600c588299420e1435ac642bd2cedef"
-  integrity sha512-Uqg+2JdMKecmOmnfye06xrYx+Gg5iwhJcfkOv6p7MdlRspR0h02CwoDvM/ftOjTYp+Axi6+EWZHq8Um97JXcGQ==
+mapbox-gl@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/mapbox-gl/-/mapbox-gl-1.8.1.tgz#83fd2e99274a226adbf1c01012c37d17fccdd4bc"
+  integrity sha512-Q6c8XAFxHxMPnZIfiRsExk5dNN+dCgvbRNHPfX7hHV5LDcX5Ptc1MEVpOJEDyojuriZssAeWMTJob0hir9mpUw==
   dependencies:
     "@mapbox/geojson-rewind" "^0.4.0"
     "@mapbox/geojson-types" "^1.0.2"


### PR DESCRIPTION
There was an [issue](https://github.com/mapbox/mapbox-gl-js/issues/9327) in the previous mapbox-gl version (1.8.0), causing map labels to align diagonally across the map. The issue only occurres on Windows machines with particular hardware, on Chrome and Edge browsers, as documented in the issue. The bug was fixed in the followup version [1.8.1](https://github.com/mapbox/mapbox-gl-js/releases/tag/v1.8.1)