### PR TITLE
Use netzkarte_eisenbahninfrastruktur_v2 style

### DIFF
--- a/src/config/layers.js
+++ b/src/config/layers.js
@@ -672,7 +672,7 @@ export const tochtergesellschaftenSBB = new MapboxStyleLayer({
   visible: true,
   mapboxLayer: netzkarteEisenbahninfrastruktur,
   styleLayersFilter: styleLayer => {
-    return /_SBB/.test(styleLayer.id);
+    return /(?<!only)_SBB/.test(styleLayer.id);
   },
   properties: {
     hasInfos: true,
@@ -698,7 +698,7 @@ export const uebrigeBahnen = new MapboxStyleLayer({
   visible: true,
   mapboxLayer: netzkarteEisenbahninfrastruktur,
   styleLayersFilter: styleLayer => {
-    return /_KTU/.test(styleLayer.id);
+    return /(?<!only)_KTU/.test(styleLayer.id);
   },
   properties: {
     hasInfos: true,

--- a/src/config/layers.js
+++ b/src/config/layers.js
@@ -660,7 +660,7 @@ export const netzkarteEisenbahninfrastruktur = new TrafimageMapboxLayer({
   isQueryable: false,
   preserveDrawingBuffer: true,
   zIndex: -1,
-  style: 'netzkarte_eisenbahninfrastruktur',
+  style: 'netzkarte_eisenbahninfrastruktur_v2',
   properties: {
     hasInfos: true,
     layerInfoComponent: 'InfrastrukturTopicInfo',

--- a/src/config/layers.js
+++ b/src/config/layers.js
@@ -671,8 +671,9 @@ export const tochtergesellschaftenSBB = new MapboxStyleLayer({
   name: 'ch.sbb.infrastruktur.tochtergesellschaften.group',
   visible: true,
   mapboxLayer: netzkarteEisenbahninfrastruktur,
-  styleLayersFilter: styleLayer => {
-    return /(?<!only)_SBB/.test(styleLayer.id);
+  styleLayersFilter: ({ id }) => {
+    // negative look behind regex doesn't work on all browsers.
+    return /_SBB/.test(id) && id.indexOf('_only_') === -1;
   },
   properties: {
     hasInfos: true,
@@ -697,8 +698,9 @@ export const uebrigeBahnen = new MapboxStyleLayer({
   name: 'ch.sbb.infrastruktur.uebrigebahnen.group',
   visible: true,
   mapboxLayer: netzkarteEisenbahninfrastruktur,
-  styleLayersFilter: styleLayer => {
-    return /(?<!only)_KTU/.test(styleLayer.id);
+  styleLayersFilter: ({ id }) => {
+    // negative look behind regex doesn't work on all browsers.
+    return /_KTU/.test(id) && id.indexOf('_only_') === -1;
   },
   properties: {
     hasInfos: true,


### PR DESCRIPTION
# How to

<!--  Please provide a test link and quick description how to see the change -->
Open the Netzkarte eisenbahninfrastruktur topic, at level 11 the road number should be displayed.

[Style v1](https://maps2.trafimage.ch/ch.sbb.infrastruktur?lang=de&layers=ch.sbb.infrastruktur.gewaesser.group,ch.sbb.infrastruktur.uebrigebahnen.group,ch.sbb.infrastruktur.tochtergesellschaften.group&x=845213.12&y=5955390.34&z=11)
[Style v2](https://deploy-preview-617--dev-trafimage-maps.netlify.com/?lang=de&layers=ch.sbb.infrastruktur.gewaesser.group,ch.sbb.infrastruktur.uebrigebahnen.group,ch.sbb.infrastruktur.tochtergesellschaften.group&x=835677.71&y=5962704.88&z=11)

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] Labels applied. if it's a release? a hotfix?
- [x] IE tested

