### PR TITLE
Test: Gevos/zweitausbildung patches test

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -160,7 +160,7 @@
       zoom="12"
       center="[810000, 5900000]"
       appName="wkp"
-      activeTopicKey="ch.sbb.netzkarte"
+      activeTopicKey="ch.sbb.zweitausbildung"
       permissionUrl="//maps.trafimage.ch"
     ></trafimage-maps>
     <button


### PR DESCRIPTION
This is only a test PR (as the topic zweitausbildung is hidden in the LayerTree).
Use https://github.com/geops/trafimage-maps/pull/638 for review and merging.