### PR TITLE
FeatureInformation: Don't put the padding on body but on the child

### DIFF
--- a/src/components/FeatureInformation/FeatureInformation.scss
+++ b/src/components/FeatureInformation/FeatureInformation.scss
@@ -25,13 +25,15 @@
   }
 
   .wkp-feature-information-body {
-    padding: 10px;
+    > div {
+      padding: 10px;
+    }
 
     .wkp-pagination-wrapper {
       display: flex;
       align-items: center;
       justify-content: center;
-      padding-top: 5px;
+      padding-top: 0;
 
       .wkp-pagination-button-wrapper {
         padding: 0 10px;


### PR DESCRIPTION
# How to

<!--  Please provide a test link and quick description how to see the change -->
Risky PR ever. Change the padding of the feature-information popup.
This will allow the layer popup element to have an overflow without using a hack.

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] IE11 tested.
- [x] Labels applied. if it's a release? a hotfix?
