### PR TITLE
Gevos/zweitausbildung: use variables from properties instead of env

### DIFF
--- a/src/WebComponent.js
+++ b/src/WebComponent.js
@@ -92,6 +92,11 @@ const propTypes = {
   vectorTilesUrl: PropTypes.string,
 
   /**
+   * URL of the static files. Default is 'https://maps2.trafimage.ch'.
+   */
+  staticFilesUrl: PropTypes.string,
+
+  /**
    * URL to request permission.
    */
   permissionUrl: PropTypes.string,
@@ -116,6 +121,7 @@ const attributes = {
   appBaseUrl: process.env.REACT_APP_BASE_URL,
   vectorTilesKey: process.env.REACT_APP_VECTOR_TILES_KEY,
   vectorTilesUrl: process.env.REACT_APP_VECTOR_TILES_URL,
+  staticFilesUrl: process.env.REACT_APP_STATIC_FILES_URL,
   permissionUrl: null,
   enableTracking: false,
 };

--- a/src/components/FeatureInformation/FeatureInformation.js
+++ b/src/components/FeatureInformation/FeatureInformation.js
@@ -12,9 +12,14 @@ import './FeatureInformation.scss';
 
 const propTypes = {
   featureInfo: PropTypes.array.isRequired,
+  staticFilesUrl: PropTypes.string,
 };
 
-const FeatureInformation = ({ featureInfo }) => {
+const defaultProps = {
+  staticFilesUrl: null,
+};
+
+const FeatureInformation = ({ featureInfo, staticFilesUrl }) => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
   const [featureIndex, setFeatureIndex] = useState(0);
@@ -98,6 +103,7 @@ const FeatureInformation = ({ featureInfo }) => {
           <PopupComponent
             key={info.layer.getKey()}
             feature={features[featureIndex]}
+            staticFilesUrl={staticFilesUrl}
           />
           {pagination}
         </div>
@@ -107,5 +113,6 @@ const FeatureInformation = ({ featureInfo }) => {
 };
 
 FeatureInformation.propTypes = propTypes;
+FeatureInformation.defaultProps = defaultProps;
 
 export default React.memo(FeatureInformation);

--- a/src/components/FeatureInformation/FeatureInformation.js
+++ b/src/components/FeatureInformation/FeatureInformation.js
@@ -12,14 +12,16 @@ import './FeatureInformation.scss';
 
 const propTypes = {
   featureInfo: PropTypes.array.isRequired,
+  appBaseUrl: PropTypes.string,
   staticFilesUrl: PropTypes.string,
 };
 
 const defaultProps = {
+  appBaseUrl: null,
   staticFilesUrl: null,
 };
 
-const FeatureInformation = ({ featureInfo, staticFilesUrl }) => {
+const FeatureInformation = ({ featureInfo, appBaseUrl, staticFilesUrl }) => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
   const [featureIndex, setFeatureIndex] = useState(0);
@@ -103,6 +105,7 @@ const FeatureInformation = ({ featureInfo, staticFilesUrl }) => {
           <PopupComponent
             key={info.layer.getKey()}
             feature={features[featureIndex]}
+            appBaseUrl={appBaseUrl}
             staticFilesUrl={staticFilesUrl}
           />
           {pagination}

--- a/src/components/FeatureMenu/FeatureMenu.js
+++ b/src/components/FeatureMenu/FeatureMenu.js
@@ -7,14 +7,16 @@ import FeatureInformation from '../FeatureInformation';
 import MenuItem from '../Menu/MenuItem';
 
 const propTypes = {
+  appBaseUrl: PropTypes.string,
   staticFilesUrl: PropTypes.string,
 };
 
 const defaultProps = {
+  appBaseUrl: null,
   staticFilesUrl: null,
 };
 
-const FeatureMenu = ({ staticFilesUrl }) => {
+const FeatureMenu = ({ appBaseUrl, staticFilesUrl }) => {
   const { t } = useTranslation();
   const featureInfo = useSelector((state) => state.app.featureInfo);
   const [collapsed, setCollapsed] = useState(false);
@@ -34,6 +36,7 @@ const FeatureMenu = ({ staticFilesUrl }) => {
     >
       <FeatureInformation
         featureInfo={featureInfo}
+        appBaseUrl={appBaseUrl}
         staticFilesUrl={staticFilesUrl}
       />
     </MenuItem>

--- a/src/components/FeatureMenu/FeatureMenu.js
+++ b/src/components/FeatureMenu/FeatureMenu.js
@@ -1,11 +1,20 @@
 import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
+import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
 import { FaInfo } from 'react-icons/fa';
 import FeatureInformation from '../FeatureInformation';
 import MenuItem from '../Menu/MenuItem';
 
-const FeatureMenu = () => {
+const propTypes = {
+  staticFilesUrl: PropTypes.string,
+};
+
+const defaultProps = {
+  staticFilesUrl: null,
+};
+
+const FeatureMenu = ({ staticFilesUrl }) => {
   const { t } = useTranslation();
   const featureInfo = useSelector((state) => state.app.featureInfo);
   const [collapsed, setCollapsed] = useState(false);
@@ -23,9 +32,15 @@ const FeatureMenu = () => {
       collapsed={collapsed}
       onCollapseToggle={(c) => setCollapsed(c)}
     >
-      <FeatureInformation featureInfo={featureInfo} />
+      <FeatureInformation
+        featureInfo={featureInfo}
+        staticFilesUrl={staticFilesUrl}
+      />
     </MenuItem>
   );
 };
+
+FeatureMenu.propTypes = propTypes;
+FeatureMenu.defaultProps = defaultProps;
 
 export default FeatureMenu;

--- a/src/components/LayerInfosDialog/LayerInfosDialog.js
+++ b/src/components/LayerInfosDialog/LayerInfosDialog.js
@@ -8,10 +8,12 @@ import layerInfos from '../../layerInfos';
 
 const propTypes = {
   selectedForInfos: PropTypes.object,
+  staticFilesUrl: PropTypes.string,
 };
 
 const defaultProps = {
   selectedForInfos: null,
+  staticFilesUrl: null,
 };
 
 export const NAME = 'infoDialog';
@@ -19,7 +21,7 @@ export const NAME = 'infoDialog';
 function LayerInfosDialog(props) {
   const language = useSelector((state) => state.app.language);
   const { t } = useTranslation();
-  const { selectedForInfos } = props;
+  const { selectedForInfos, staticFilesUrl } = props;
 
   if (!selectedForInfos) {
     return null;
@@ -39,7 +41,11 @@ function LayerInfosDialog(props) {
   if (componentName) {
     const LayerInfoComponent = layerInfos[componentName];
     body = (
-      <LayerInfoComponent language={language} properties={selectedForInfos} />
+      <LayerInfoComponent
+        language={language}
+        properties={selectedForInfos}
+        staticFilesUrl={staticFilesUrl}
+      />
     );
   } else if (description) {
     body = <Trans i18nKey={description} />;

--- a/src/components/MainDialog/MainDialog.js
+++ b/src/components/MainDialog/MainDialog.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { useSelector, useDispatch } from 'react-redux';
 import { FaInfo } from 'react-icons/fa';
 import { useTranslation } from 'react-i18next';
@@ -9,7 +10,15 @@ import Dialog from '../Dialog';
 import LegalLines from '../LegalLines';
 import { setDialogPosition } from '../../model/app/actions';
 
-const MainDialog = () => {
+const propTypes = {
+  staticFilesUrl: PropTypes.string,
+};
+
+const defaultProps = {
+  staticFilesUrl: null,
+};
+
+const MainDialog = ({ staticFilesUrl }) => {
   const dispatch = useDispatch();
   const { t } = useTranslation();
   const dialogVisible = useSelector((state) => state.app.dialogVisible);
@@ -20,6 +29,7 @@ const MainDialog = () => {
     return (
       <LayerInfosDialog
         selectedForInfos={selectedForInfos}
+        staticFilesUrl={staticFilesUrl}
         onDragStop={(evt, pos) => {
           dispatch(
             setDialogPosition({
@@ -51,5 +61,8 @@ const MainDialog = () => {
 
   return null;
 };
+
+MainDialog.propTypes = propTypes;
+MainDialog.defaultProps = defaultProps;
 
 export default MainDialog;

--- a/src/components/Popup/Popup.js
+++ b/src/components/Popup/Popup.js
@@ -1,10 +1,19 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
+import PropTypes from 'prop-types';
 import { Point, LineString } from 'ol/geom';
 import RSPopup from 'react-spatial/components/Popup';
 import FeatureInformation from '../FeatureInformation';
 
-const Popup = () => {
+const propTypes = {
+  staticFilesUrl: PropTypes.string,
+};
+
+const defaultProps = {
+  staticFilesUrl: null,
+};
+
+const Popup = ({ staticFilesUrl }) => {
   const map = useSelector((state) => state.app.map);
   const { activeTopic, featureInfo } = useSelector((state) => state.app);
 
@@ -60,9 +69,15 @@ const Popup = () => {
       popupCoordinate={coord}
       map={map}
     >
-      <FeatureInformation featureInfo={filtered} />
+      <FeatureInformation
+        featureInfo={filtered}
+        staticFilesUrl={staticFilesUrl}
+      />
     </RSPopup>
   );
 };
+
+Popup.propTypes = propTypes;
+Popup.defaultProps = defaultProps;
 
 export default React.memo(Popup);

--- a/src/components/Popup/Popup.js
+++ b/src/components/Popup/Popup.js
@@ -6,14 +6,16 @@ import RSPopup from 'react-spatial/components/Popup';
 import FeatureInformation from '../FeatureInformation';
 
 const propTypes = {
+  appBaseUrl: PropTypes.string,
   staticFilesUrl: PropTypes.string,
 };
 
 const defaultProps = {
+  appBaseUrl: null,
   staticFilesUrl: null,
 };
 
-const Popup = ({ staticFilesUrl }) => {
+const Popup = ({ appBaseUrl, staticFilesUrl }) => {
   const map = useSelector((state) => state.app.map);
   const { activeTopic, featureInfo } = useSelector((state) => state.app);
 
@@ -71,6 +73,7 @@ const Popup = ({ staticFilesUrl }) => {
     >
       <FeatureInformation
         featureInfo={filtered}
+        appBaseUrl={appBaseUrl}
         staticFilesUrl={staticFilesUrl}
       />
     </RSPopup>

--- a/src/components/TopicElements/TopicElements.js
+++ b/src/components/TopicElements/TopicElements.js
@@ -110,7 +110,7 @@ function TopicElements({ history, appBaseUrl, staticFilesUrl }) {
   // Define which component to display as child of Menu.
   const appMenuChildren = getComponents(
     {
-      featureMenu: <FeatureMenu />,
+      featureMenu: <FeatureMenu staticFilesUrl={staticFilesUrl} />,
       trackerMenu: <TrackerMenu />,
     },
     elements,
@@ -121,7 +121,7 @@ function TopicElements({ history, appBaseUrl, staticFilesUrl }) {
     header: <Header appBaseUrl={appBaseUrl} />,
     search: <Search />,
     telephoneInfos: <TopicTelephoneInfos />,
-    popup: <Popup />,
+    popup: <Popup staticFilesUrl={staticFilesUrl} />,
     permalink: <Permalink history={history} appBaseUrl={appBaseUrl} />,
     menu: (
       <Menu>

--- a/src/components/TopicElements/TopicElements.js
+++ b/src/components/TopicElements/TopicElements.js
@@ -46,11 +46,13 @@ const propTypes = {
     replace: PropTypes.func,
   }),
   appBaseUrl: PropTypes.string,
+  staticFilesUrl: PropTypes.string,
 };
 
 const defaultProps = {
   history: null,
   appBaseUrl: null,
+  staticFilesUrl: null,
 };
 
 const getComponents = (defaultComponents, elementsToDisplay) =>
@@ -58,7 +60,7 @@ const getComponents = (defaultComponents, elementsToDisplay) =>
     elementsToDisplay[k] ? <div key={k}>{v}</div> : null,
   );
 
-function TopicElements({ history, appBaseUrl }) {
+function TopicElements({ history, appBaseUrl, staticFilesUrl }) {
   const ref = useRef(null);
   const { activeTopic, layerService, map } = useSelector((state) => state.app);
   const [tabFocus, setTabFocus] = useState(false);
@@ -137,7 +139,7 @@ function TopicElements({ history, appBaseUrl }) {
           prevButton: t('Nächste Baselayer'),
           nextButton: t('Vorherige Baselayer'),
         }}
-        fallbackImgDir={`${process.env.REACT_APP_STATIC_FILES_URL}/img/baselayer/`}
+        fallbackImgDir={`${staticFilesUrl}/img/baselayer/`}
         validExtent={[656409.5, 5740863.4, 1200512.3, 6077033.16]}
       />
     ),
@@ -160,7 +162,7 @@ function TopicElements({ history, appBaseUrl }) {
           )}
         </EventConsumer>
         {appElements}
-        <MainDialog />
+        <MainDialog staticFilesUrl={staticFilesUrl} />
       </div>
     </div>
   );

--- a/src/components/TopicElements/TopicElements.js
+++ b/src/components/TopicElements/TopicElements.js
@@ -110,7 +110,9 @@ function TopicElements({ history, appBaseUrl, staticFilesUrl }) {
   // Define which component to display as child of Menu.
   const appMenuChildren = getComponents(
     {
-      featureMenu: <FeatureMenu staticFilesUrl={staticFilesUrl} />,
+      featureMenu: (
+        <FeatureMenu appBaseUrl={appBaseUrl} staticFilesUrl={staticFilesUrl} />
+      ),
       trackerMenu: <TrackerMenu />,
     },
     elements,
@@ -121,7 +123,7 @@ function TopicElements({ history, appBaseUrl, staticFilesUrl }) {
     header: <Header appBaseUrl={appBaseUrl} />,
     search: <Search />,
     telephoneInfos: <TopicTelephoneInfos />,
-    popup: <Popup staticFilesUrl={staticFilesUrl} />,
+    popup: <Popup appBaseUrl={appBaseUrl} staticFilesUrl={staticFilesUrl} />,
     permalink: <Permalink history={history} appBaseUrl={appBaseUrl} />,
     menu: (
       <Menu>

--- a/src/components/TopicLoader/TopicLoader.js
+++ b/src/components/TopicLoader/TopicLoader.js
@@ -30,6 +30,7 @@ const propTypes = {
   permissionUrl: PropTypes.string,
   vectorTilesKey: PropTypes.string,
   vectorTilesUrl: PropTypes.string,
+  staticFilesUrl: PropTypes.string,
 
   // mapStateToProps
   activeTopic: PropTypes.shape(),
@@ -59,6 +60,7 @@ const defaultProps = {
   vectorTilesUrl: null,
   permissionUrl: null,
   permissionsInfos: null,
+  staticFilesUrl: null,
 };
 
 class TopicLoader extends Component {
@@ -84,6 +86,7 @@ class TopicLoader extends Component {
       vectorTilesKey,
       vectorTilesUrl,
       permissionUrl,
+      staticFilesUrl,
       dispatchFetchPermissionsInfos,
     } = this.props;
 
@@ -108,7 +111,8 @@ class TopicLoader extends Component {
       vectorTilesKey !== prevProps.vectorTilesKey ||
       vectorTilesUrl !== prevProps.vectorTilesUrl ||
       cartaroUrl !== prevProps.cartaroUrl ||
-      appBaseUrl !== prevProps.appBaseUrl
+      appBaseUrl !== prevProps.appBaseUrl ||
+      staticFilesUrl !== prevProps.staticFilesUrl
     ) {
       this.updateServices(activeTopic);
     }
@@ -212,6 +216,7 @@ class TopicLoader extends Component {
       appBaseUrl,
       vectorTilesKey,
       vectorTilesUrl,
+      staticFilesUrl,
     } = this.props;
 
     const [currentBaseLayer] = layerService
@@ -253,16 +258,24 @@ class TopicLoader extends Component {
       if (flatLayers[i].setCartaroUrl) {
         flatLayers[i].setCartaroUrl(cartaroUrl);
       }
-
       if (flatLayers[i].setLanguage) {
         flatLayers[i].setLanguage(language);
+      }
+      if (flatLayers[i].setStaticFilesUrl) {
+        flatLayers[i].setStaticFilesUrl(staticFilesUrl);
       }
     }
   }
 
   render() {
-    const { history, appBaseUrl } = this.props;
-    return <TopicElements history={history} appBaseUrl={appBaseUrl} />;
+    const { history, appBaseUrl, staticFilesUrl } = this.props;
+    return (
+      <TopicElements
+        history={history}
+        appBaseUrl={appBaseUrl}
+        staticFilesUrl={staticFilesUrl}
+      />
+    );
   }
 }
 

--- a/src/components/TrafimageMaps/TrafimageMaps.js
+++ b/src/components/TrafimageMaps/TrafimageMaps.js
@@ -101,6 +101,11 @@ const propTypes = {
    * @private
    */
   enableTracking: PropTypes.bool,
+
+  /**
+   * URL endpoint for static files.
+   */
+  staticFilesUrl: PropTypes.string,
 };
 
 const defaultProps = {
@@ -113,6 +118,7 @@ const defaultProps = {
   appBaseUrl: process.env.REACT_APP_BASE_URL,
   vectorTilesKey: process.env.REACT_APP_VECTOR_TILES_KEY,
   vectorTilesUrl: process.env.REACT_APP_VECTOR_TILES_URL,
+  staticFilesUrl: process.env.REACT_APP_STATIC_FILES_URL,
   permissionUrl: null,
   topics: null,
   language: 'de',
@@ -194,6 +200,7 @@ class TrafimageMaps extends React.PureComponent {
       appBaseUrl,
       vectorTilesKey,
       vectorTilesUrl,
+      staticFilesUrl,
       permissionUrl,
       enableTracking,
     } = this.props;
@@ -210,6 +217,7 @@ class TrafimageMaps extends React.PureComponent {
             permissionUrl={permissionUrl}
             vectorTilesKey={vectorTilesKey}
             vectorTilesUrl={vectorTilesUrl}
+            staticFilesUrl={staticFilesUrl}
           />
         </Provider>
       </MatomoProvider>

--- a/src/layerInfos/BehigLayerInfo/BehigLayerInfo.js
+++ b/src/layerInfos/BehigLayerInfo/BehigLayerInfo.js
@@ -10,17 +10,18 @@ const propTypes = {
   t: PropTypes.func.isRequired,
   language: PropTypes.string.isRequired,
   properties: PropTypes.object.isRequired,
+  staticFilesUrl: PropTypes.string.isRequired,
 };
 
 const defaultProps = {};
 
-const BehigLayerInfo = ({ t, language, properties }) => {
+const BehigLayerInfo = ({ t, language, properties, staticFilesUrl }) => {
   const config = properties.get('behig');
   const key = config.status.replace(/\s/g, '_');
 
   const img = (
     <img
-      src={`${process.env.REACT_APP_STATIC_FILES_URL}/img/layers/behig/${key}.png`}
+      src={`${staticFilesUrl}/img/layers/behig/${key}.png`}
       draggable="false"
       alt={t('Kein Bildtext')}
     />

--- a/src/layerInfos/BehigTopicInfo/BehigTopicInfo.js
+++ b/src/layerInfos/BehigTopicInfo/BehigTopicInfo.js
@@ -5,14 +5,16 @@ import { compose } from 'lodash/fp';
 
 const propTypes = {
   t: PropTypes.func.isRequired,
+  language: PropTypes.string.isRequired,
+  staticFilesUrl: PropTypes.string.isRequired,
 };
 
 const defaultProps = {};
 
-const BehigTopicInfo = ({ language, t }) => {
+const BehigTopicInfo = ({ language, t, staticFilesUrl }) => {
   const img = (
     <img
-      src={`${process.env.REACT_APP_STATIC_FILES_URL}/img/topics/behig/behig_legend_${language}.jpg`}
+      src={`${staticFilesUrl}/img/topics/behig/behig_legend_${language}.jpg`}
       draggable="false"
       alt={t('Kein Bildtext')}
     />

--- a/src/layerInfos/ConstructionLayerInfo/ConstructionLayerInfo.js
+++ b/src/layerInfos/ConstructionLayerInfo/ConstructionLayerInfo.js
@@ -8,11 +8,12 @@ import './ConstructionLayerInfo.scss';
 const propTypes = {
   t: PropTypes.func.isRequired,
   properties: PropTypes.object.isRequired,
+  staticFilesUrl: PropTypes.string.isRequired,
 };
 
 const defaultProps = {};
 
-const ConstructionLayerInfo = ({ t, properties }) => {
+const ConstructionLayerInfo = ({ t, properties, staticFilesUrl }) => {
   const config = properties.get('construction');
   const filename = `${config.art}_${config.ort}`.replace(
     /[^A-Z,^0-9,-_]/gi,
@@ -22,7 +23,7 @@ const ConstructionLayerInfo = ({ t, properties }) => {
   return (
     <div className="wkp-construction-layer-info">
       <img
-        src={`${process.env.REACT_APP_STATIC_FILES_URL}/img/layers/construction/${filename}.png`}
+        src={`${staticFilesUrl}/img/layers/construction/${filename}.png`}
         draggable="false"
         alt={t('Kein Bildtext')}
       />

--- a/src/layerInfos/PunctualityLayerInfo/PunctualityLayerInfo.js
+++ b/src/layerInfos/PunctualityLayerInfo/PunctualityLayerInfo.js
@@ -5,14 +5,15 @@ import { compose } from 'lodash/fp';
 
 const propTypes = {
   t: PropTypes.func.isRequired,
+  staticFilesUrl: PropTypes.string.isRequired,
 };
 
 const defaultProps = {};
 
-const PunctualityLayerInfo = ({ language, t }) => {
+const PunctualityLayerInfo = ({ language, t, staticFilesUrl }) => {
   const img = (
     <img
-      src={`${process.env.REACT_APP_STATIC_FILES_URL}/img/layers/puenktlichkeit/puenktlichkeit_legend_${language}.png`}
+      src={`${staticFilesUrl}/img/layers/puenktlichkeit/puenktlichkeit_legend_${language}.png`}
       draggable="false"
       alt={t('Kein Bildtext')}
     />

--- a/src/layerInfos/TarifverbundkarteTopicInfo/TarifverbundkarteTopicInfo.js
+++ b/src/layerInfos/TarifverbundkarteTopicInfo/TarifverbundkarteTopicInfo.js
@@ -5,14 +5,16 @@ import { compose } from 'lodash/fp';
 
 const propTypes = {
   t: PropTypes.func.isRequired,
+  language: PropTypes.string.isRequired,
+  staticFilesUrl: PropTypes.string.isRequired,
 };
 
 const defaultProps = {};
 
-const TarifverbundkarteTopicInfo = ({ language, t }) => {
+const TarifverbundkarteTopicInfo = ({ language, t, staticFilesUrl }) => {
   const img = (
     <img
-      src={`${process.env.REACT_APP_STATIC_FILES_URL}/img/topics/tarifverbundkarte/tarifverbundkarte_legend.png`}
+      src={`${staticFilesUrl}/img/topics/tarifverbundkarte/tarifverbundkarte_legend.png`}
       draggable="false"
       alt={t('Kein Bildtext')}
     />

--- a/src/layerInfos/ZweitausbildungLayerInfo/ZweitausbildungLayerInfo.js
+++ b/src/layerInfos/ZweitausbildungLayerInfo/ZweitausbildungLayerInfo.js
@@ -6,9 +6,10 @@ import { compose } from 'lodash/fp';
 const propTypes = {
   t: PropTypes.func.isRequired,
   properties: PropTypes.object.isRequired,
+  staticFilesUrl: PropTypes.string.isRequired,
 };
 
-const ZweitausbildungLayerInfo = ({ t, properties }) => {
+const ZweitausbildungLayerInfo = ({ t, properties, staticFilesUrl }) => {
   const { infos } = properties.get('zweitausbildung');
   const { title, legend } = infos;
 
@@ -18,7 +19,7 @@ const ZweitausbildungLayerInfo = ({ t, properties }) => {
       {legend ? (
         <div className="wkp-zweitausbildung-layer-info-legend">
           <img
-            src={`${process.env.REACT_APP_STATIC_FILES_URL}/img/layers/zweitausbildung/${legend.image}`}
+            src={`${staticFilesUrl}/img/layers/zweitausbildung/${legend.image}`}
             draggable="false"
             alt={t('Kein Bildtext')}
           />

--- a/src/layerInfos/ZweitausbildungRoutesSubLayerInfo/ZweitausbildungRoutesSubLayerInfo.js
+++ b/src/layerInfos/ZweitausbildungRoutesSubLayerInfo/ZweitausbildungRoutesSubLayerInfo.js
@@ -6,9 +6,14 @@ import { compose } from 'lodash/fp';
 const propTypes = {
   t: PropTypes.func.isRequired,
   properties: PropTypes.object.isRequired,
+  staticFilesUrl: PropTypes.string.isRequired,
 };
 
-const ZweitausbildungRoutesSubLayerInfo = ({ t, properties }) => {
+const ZweitausbildungRoutesSubLayerInfo = ({
+  t,
+  properties,
+  staticFilesUrl,
+}) => {
   const { infos } = properties.get('zweitausbildung');
   const { title, desc, legend } = infos;
 
@@ -20,7 +25,7 @@ const ZweitausbildungRoutesSubLayerInfo = ({ t, properties }) => {
       </div>
       <div className="wkp-zweitausbildung-routes-sub-layer-info-legend">
         <img
-          src={`${process.env.REACT_APP_STATIC_FILES_URL}/img/layers/zweitausbildung/${legend.image}`}
+          src={`${staticFilesUrl}/img/layers/zweitausbildung/${legend.image}`}
           draggable="false"
           alt={t('Kein Bildtext')}
         />

--- a/src/layerInfos/ZweitausbildungSubLayerInfo/ZweitausbildungSubLayerInfo.js
+++ b/src/layerInfos/ZweitausbildungSubLayerInfo/ZweitausbildungSubLayerInfo.js
@@ -6,9 +6,10 @@ import { compose } from 'lodash/fp';
 const propTypes = {
   t: PropTypes.func.isRequired,
   properties: PropTypes.object.isRequired,
+  staticFilesUrl: PropTypes.string.isRequired,
 };
 
-const ZweitausbildungSubLayerInfo = ({ t, properties }) => {
+const ZweitausbildungSubLayerInfo = ({ t, properties, staticFilesUrl }) => {
   const { infos } = properties.get('zweitausbildung');
   const { title, legend } = infos;
 
@@ -23,7 +24,7 @@ const ZweitausbildungSubLayerInfo = ({ t, properties }) => {
         {legend.map((item) => (
           <div>
             <img
-              src={`${process.env.REACT_APP_STATIC_FILES_URL}/img/layers/zweitausbildung/${item.image}`}
+              src={`${staticFilesUrl}/img/layers/zweitausbildung/${item.image}`}
               draggable="false"
               alt={t('Kein Bildtext')}
             />

--- a/src/layers/BehigLayer/BehigLayer.js
+++ b/src/layers/BehigLayer/BehigLayer.js
@@ -79,6 +79,10 @@ class BehigLayer extends VectorLayer {
     this.geoJsonCacheUrl = geoJsonCacheUrl;
   }
 
+  setStaticFilesUrl(staticFilesUrl) {
+    this.staticFilesUrl = staticFilesUrl;
+  }
+
   /**
    * Function that returns a geometry if the feature should be visible.
    * @param  {ol.feature} feature Feature
@@ -114,7 +118,7 @@ class BehigLayer extends VectorLayer {
           new Style({
             zIndex: 3,
             image: new Icon({
-              src: `${process.env.REACT_APP_STATIC_FILES_URL}/img/layers/behig/${filename}.png`,
+              src: `${this.staticFilesUrl}/img/layers/behig/${filename}.png`,
             }),
           }),
         ];

--- a/src/layers/ConstructionLayer/ConstructionLayer.js
+++ b/src/layers/ConstructionLayer/ConstructionLayer.js
@@ -143,6 +143,10 @@ class ConstructionLayer extends VectorLayer {
     this.geoServerUrl = geoServerUrl;
   }
 
+  setStaticFilesUrl(staticFilesUrl) {
+    this.staticFilesUrl = staticFilesUrl;
+  }
+
   /**
    * Function that returns a geometry if the feature should be visible.
    * @param  {ol.feature} feature Feature
@@ -208,7 +212,7 @@ class ConstructionLayer extends VectorLayer {
       this.styleCache[cacheKey] = [
         new Style({
           image: new Icon({
-            src: `${process.env.REACT_APP_STATIC_FILES_URL}/img/layers/construction/${filename}.png`,
+            src: `${this.staticFilesUrl}/img/layers/construction/${filename}.png`,
           }),
         }),
       ];

--- a/src/layers/ZweitausbildungAbroadLayer/ZweitausbildungAbroadLayer.js
+++ b/src/layers/ZweitausbildungAbroadLayer/ZweitausbildungAbroadLayer.js
@@ -45,6 +45,10 @@ class ZweitausbildungAbroadLayer extends VectorLayer {
     this.olLayer.changed();
   }
 
+  setStaticFilesUrl(staticFilesUrl) {
+    this.staticFilesUrl = staticFilesUrl;
+  }
+
   style(feature, resolution) {
     const text = feature.get(`title_${this.language}`);
     const hover = feature.get('hoverStyle');
@@ -68,7 +72,7 @@ class ZweitausbildungAbroadLayer extends VectorLayer {
         }),
         new Style({
           image: new Icon({
-            src: `${process.env.REACT_APP_STATIC_FILES_URL}/img/layers/zweitausbildung/button_rectangle.png`,
+            src: `${this.staticFilesUrl}/img/layers/zweitausbildung/button_rectangle.png`,
             anchor: [0.4, 0.505],
           }),
         }),

--- a/src/layers/ZweitausbildungPoisLayer/ZweitausbildungPoisLayer.js
+++ b/src/layers/ZweitausbildungPoisLayer/ZweitausbildungPoisLayer.js
@@ -74,6 +74,10 @@ class ZweitausbildungPoisLayer extends VectorLayer {
     this.geoServerUrl = geoServerUrl;
   }
 
+  setStaticFilesUrl(staticFilesUrl) {
+    this.staticFilesUrl = staticFilesUrl;
+  }
+
   init(map) {
     super.init(map);
 
@@ -173,7 +177,7 @@ class ZweitausbildungPoisLayer extends VectorLayer {
           new Style({
             zIndex: 3,
             image: new Icon({
-              src: `${process.env.REACT_APP_STATIC_FILES_URL}/img/layers/zweitausbildung/poi.png`,
+              src: `${this.staticFilesUrl}/img/layers/zweitausbildung/poi.png`,
             }),
           }),
         ];

--- a/src/layers/ZweitausbildungRoutesHighlightLayer/ZweitausbildungRoutesHighlightLayer.js
+++ b/src/layers/ZweitausbildungRoutesHighlightLayer/ZweitausbildungRoutesHighlightLayer.js
@@ -101,9 +101,9 @@ class ZweitausbildungRoutesHighlightLayer extends VectorLayer {
       if (this.options.indexOf(label) === -1) {
         this.options.push(label);
         this.icons[label] = feature.get('line_number')
-          ? `${
-              process.env.REACT_APP_STATIC_FILES_URL
-            }/img/layers/zweitausbildung/${feature.get('line_number')}.png`
+          ? `${this.staticFilesUrl}/img/layers/zweitausbildung/${feature.get(
+              'line_number',
+            )}.png`
           : null;
       }
     }
@@ -205,6 +205,10 @@ class ZweitausbildungRoutesHighlightLayer extends VectorLayer {
 
   setGeoServerUrl(geoServerUrl) {
     this.geoServerUrl = geoServerUrl;
+  }
+
+  setStaticFilesUrl(staticFilesUrl) {
+    this.staticFilesUrl = staticFilesUrl;
   }
 
   style(feature, resolution) {

--- a/src/popups/DeparturePopup/DeparturePopup.js
+++ b/src/popups/DeparturePopup/DeparturePopup.js
@@ -10,13 +10,14 @@ import DeparturePopupContent from './DeparturePopupContent';
 
 const propTypes = {
   feature: PropTypes.instanceOf(Feature).isRequired,
+  appBaseUrl: PropTypes.string.isRequired,
 };
 
 const defaultProps = {};
 
 let returnToNetzkarte = false;
 
-const DeparturePopup = ({ feature }) => {
+const DeparturePopup = ({ feature, appBaseUrl }) => {
   const dispatch = useDispatch();
   const featureInfo = useSelector((state) => state.app.featureInfo);
   const layerService = useSelector((state) => state.app.layerService);
@@ -41,7 +42,9 @@ const DeparturePopup = ({ feature }) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  return <DeparturePopupContent name={name} uic={uic} />;
+  return (
+    <DeparturePopupContent name={name} uic={uic} appBaseUrl={appBaseUrl} />
+  );
 };
 
 DeparturePopup.propTypes = propTypes;

--- a/src/popups/DeparturePopup/DeparturePopupContent.js
+++ b/src/popups/DeparturePopup/DeparturePopupContent.js
@@ -25,6 +25,8 @@ const propTypes = {
 
   showTitle: PropTypes.bool,
 
+  appBaseUrl: PropTypes.string.isRequired,
+
   // react-i18next
   t: PropTypes.func.isRequired,
 
@@ -124,7 +126,7 @@ class DeparturePopupContent extends Component {
    * @private
    */
   loadDepartures() {
-    const { platforms, uic } = this.props;
+    const { platforms, uic, appBaseUrl } = this.props;
 
     const urlParams = {};
 
@@ -136,9 +138,9 @@ class DeparturePopupContent extends Component {
       urlParams.destination = `${this.destinationFilter}`;
     }
 
-    const url = `${
-      process.env.REACT_APP_BASE_URL
-    }/search/departures/${uic}?${qs.stringify(urlParams)}`;
+    const url = `${appBaseUrl}/search/departures/${uic}?${qs.stringify(
+      urlParams,
+    )}`;
 
     fetch(url)
       .then((response) => response.json())
@@ -173,7 +175,7 @@ class DeparturePopupContent extends Component {
   }
 
   render() {
-    const { platforms, uic, name, icon, showTitle, t } = this.props;
+    const { platforms, uic, name, icon, showTitle, t, appBaseUrl } = this.props;
 
     const { departuresLoading, platformName } = this.state;
     let { departures } = this.state;
@@ -229,6 +231,7 @@ class DeparturePopupContent extends Component {
           destination={this.destinationFilter}
           onSelect={(d) => this.onDestinationSelect(d)}
           uic={uic}
+          appBaseUrl={appBaseUrl}
         />
 
         {loading}

--- a/src/popups/DeparturePopup/DestinationInput.js
+++ b/src/popups/DeparturePopup/DestinationInput.js
@@ -12,6 +12,7 @@ const propTypes = {
   platforms: PropTypes.string,
   onSelect: PropTypes.func.isRequired,
   uic: PropTypes.number.isRequired,
+  appBaseUrl: PropTypes.string.isRequired,
 
   // react-i18next
   t: PropTypes.func.isRequired,
@@ -72,10 +73,10 @@ class DestinationInput extends Component {
    * @private
    */
   loadDestinations(value) {
-    const { uic, platforms } = this.props;
+    const { uic, platforms, appBaseUrl } = this.props;
 
     const url =
-      `${process.env.REACT_APP_BASE_URL}/search/destinations/${uic}` +
+      `${appBaseUrl}/search/destinations/${uic}` +
       `?platforms=${platforms || ''}&destination=${value}`;
 
     this.abortController.abort();

--- a/src/popups/ZweitausbildungPoisPopup/ZweitausbildungPoisPopup.js
+++ b/src/popups/ZweitausbildungPoisPopup/ZweitausbildungPoisPopup.js
@@ -9,6 +9,7 @@ import './ZweitausbildungPoisPopup.scss';
 const propTypes = {
   feature: PropTypes.instanceOf(Feature).isRequired,
   t: PropTypes.func.isRequired,
+  appBaseUrl: PropTypes.string.isRequired,
 };
 
 class ZweitausbildungPoisPopup extends PureComponent {
@@ -20,7 +21,7 @@ class ZweitausbildungPoisPopup extends PureComponent {
   }
 
   render() {
-    const { feature, t } = this.props;
+    const { feature, t, appBaseUrl } = this.props;
     const features = feature.get('features');
 
     return (
@@ -41,9 +42,7 @@ class ZweitausbildungPoisPopup extends PureComponent {
             <div className="wkp-zweitausbildung-pois-popup-image">
               {singleFeature.get('image') ? (
                 <img
-                  src={`${
-                    process.env.REACT_APP_BASE_URL
-                  }/cached_image?url=${encodeURIComponent(
+                  src={`${appBaseUrl}/cached_image?url=${encodeURIComponent(
                     encodeURI(singleFeature.get('image')),
                   )}`}
                   height={

--- a/src/popups/ZweitausbildungRoutesPopup/ZweitausbildungRoutesPopup.js
+++ b/src/popups/ZweitausbildungRoutesPopup/ZweitausbildungRoutesPopup.js
@@ -9,6 +9,7 @@ import './ZweitausbildungRoutesPopup.scss';
 const propTypes = {
   feature: PropTypes.instanceOf(Feature).isRequired,
   t: PropTypes.func.isRequired,
+  staticFilesUrl: PropTypes.string.isRequired,
 };
 
 class ZweitausbildungRoutesPopup extends PureComponent {
@@ -75,7 +76,7 @@ class ZweitausbildungRoutesPopup extends PureComponent {
   }
 
   render() {
-    const { t } = this.props;
+    const { t, staticFilesUrl } = this.props;
     const { features } = this.state;
 
     return (
@@ -91,9 +92,7 @@ class ZweitausbildungRoutesPopup extends PureComponent {
             {singleFeature.get('line_number') ? (
               <span className="wkp-zweitausbildung-routes-popup-image">
                 <img
-                  src={`${
-                    process.env.REACT_APP_STATIC_FILES_URL
-                  }/img/layers/zweitausbildung/${singleFeature.get(
+                  src={`${staticFilesUrl}/img/layers/zweitausbildung/${singleFeature.get(
                     'line_number',
                   )}.png`}
                   height="16"


### PR DESCRIPTION
# How to

Fix for https://github.com/geops/trafimage-maps/pull/453#discussion_r404721037

based on commit https://github.com/geops/trafimage-maps/commit/443540f089d706b2660635673e4a4af413930c6b from handicap

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized. - No images included
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] IE11 tested.
- [x] The title means something for a human being.
- [x] The title contains [WIP] if it's necessary.
- [x] Labels applied. if it's a release? a hotfix?
- [x] Tests added. - I think, it's not necessary