### PR TITLE
Fix Departure popup styling...

### DIFF
--- a/src/popups/DeparturePopup/DeparturePopupContent.scss
+++ b/src/popups/DeparturePopup/DeparturePopupContent.scss
@@ -2,8 +2,6 @@
 $tm-destination-input-height: 25px;
 
 .tm-departure-popup-body {
-  width: 100%;
-
   .tm-departure-input {
     height: $tm-destination-input-height;
     margin: 5px 0;


### PR DESCRIPTION
# How to

Fixes the departure popup styling after core change in https://github.com/geops/trafimage-maps/commit/f5841260834b52cb146559390e030320a3e18683 ("Don't put the padding on body but on the child")

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized. - No images
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] IE11 tested.
- [x] The title means something for a human being.
- [x] The title contains [WIP] if it's necessary.
- [x] Labels applied. if it's a release? a hotfix?
- [x] Tests added. - Not necessary
