### PR TITLE
Zweitausbildung: Fix listed features in tourist routes popup

### DIFF
--- a/src/layers/ZweitausbildungRoutesHighlightLayer/ZweitausbildungRoutesHighlightLayer.js
+++ b/src/layers/ZweitausbildungRoutesHighlightLayer/ZweitausbildungRoutesHighlightLayer.js
@@ -19,6 +19,15 @@ import IconList from '../../components/IconList';
  * @param {Object} [options] Layer options.
  */
 class ZweitausbildungRoutesHighlightLayer extends VectorLayer {
+  static generateLabel(feature) {
+    // viadescription for tourist routes
+    // description for hauptlinien
+    const description =
+      feature.get('viadescription') || feature.get('description');
+    const desc = description ? `: ${description}` : '';
+    return `${feature.get('bezeichnung')}${desc}`;
+  }
+
   constructor(options = {}) {
     const olLayer = new OLVectorLayer({
       style: (f, r) => this.style(f, r),
@@ -93,14 +102,9 @@ class ZweitausbildungRoutesHighlightLayer extends VectorLayer {
     for (let i = 0; i < this.features.length; i += 1) {
       const feature = this.features[i];
 
-      // viadescription for tourist routes
-      // description for hauptlinien
-      const description =
-        feature.get('viadescription') || feature.get('description');
-      const desc = description ? `: ${description}` : '';
-      const label = `${feature.get('bezeichnung')}${desc}`;
-
+      const label = ZweitausbildungRoutesHighlightLayer.generateLabel(feature);
       this.features[i].set('label', label);
+
       if (this.options.indexOf(label) === -1) {
         this.options.push(label);
         this.icons[label] = feature.get('line_number')
@@ -177,6 +181,14 @@ class ZweitausbildungRoutesHighlightLayer extends VectorLayer {
       .then((data) => {
         const format = new GeoJSON();
         const feats = format.readFeatures(data);
+
+        // Set the unique label
+        for (let i = 0; i < feats.length; i += 1) {
+          const label = ZweitausbildungRoutesHighlightLayer.generateLabel(
+            feats[i],
+          );
+          feats[i].set('label', label);
+        }
 
         const features = [];
         if (feats.length) {

--- a/src/popups/ZweitausbildungRoutesPopup/ZweitausbildungRoutesPopup.js
+++ b/src/popups/ZweitausbildungRoutesPopup/ZweitausbildungRoutesPopup.js
@@ -16,17 +16,15 @@ class ZweitausbildungRoutesPopup extends PureComponent {
   constructor(props) {
     super(props);
 
-    // Sorted unique features by bezeichnung
+    // Sorted unique features by the unique label
     const singleFeatures = props.feature
       .get('features')
       .filter((feat, pos, arr) => {
         return (
-          arr
-            .map((f) => f.get('bezeichnung'))
-            .indexOf(feat.get('bezeichnung')) === pos
+          arr.map((f) => f.get('label')).indexOf(feat.get('label')) === pos
         );
       })
-      .sort((a, b) => (a.get('bezeichnung') > b.get('bezeichnung') ? 1 : -1));
+      .sort((a, b) => (a.get('label') > b.get('label') ? 1 : -1));
 
     this.state = {
       features: singleFeatures,
@@ -61,12 +59,11 @@ class ZweitausbildungRoutesPopup extends PureComponent {
       singleFeatures[j].set('highlight', singleFeatures[j] === singleFeature);
     }
 
-    // Update the features in the map
+    // Update the features in the map, depending on the unique label
     for (let i = 0; i < highlightFeatures.length; i += 1) {
       highlightFeatures[i].set(
         'highlight',
-        highlightFeatures[i].get('bezeichnung') ===
-          singleFeature.get('bezeichnung'),
+        highlightFeatures[i].get('label') === singleFeature.get('label'),
       );
       highlightFeatures[i].changed();
     }
@@ -85,7 +82,7 @@ class ZweitausbildungRoutesPopup extends PureComponent {
             className={`wkp-zweitausbildung-routes-popup-row${
               singleFeature.get('highlight') ? ' highlight' : ''
             }`}
-            key={singleFeature.get('bezeichnung')}
+            key={singleFeature.get('label')}
             onMouseEnter={() => this.highlight(singleFeature)}
           >
             {singleFeature.get('line_number') ? (


### PR DESCRIPTION
Use the unique label to filter, sort, and compare features.
This fixes the bug where tourist routes with the same bezeichnung were missing in the popup

# How to

<!--  Please provide a test link and quick description how to see the change -->

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] IE11 tested.
- [x] The title means something for a human being.
- [x] The title contains [WIP] if it's necessary.
- [x] Labels applied. if it's a release? a hotfix?
- [x] Tests added.
