### PR TITLE
Use netzkarte_eisenbahninfrastruktur_v2

### DIFF
--- a/src/config/layers.js
+++ b/src/config/layers.js
@@ -660,7 +660,7 @@ export const netzkarteEisenbahninfrastruktur = new TrafimageMapboxLayer({
   isQueryable: false,
   preserveDrawingBuffer: true,
   zIndex: -1,
-  style: 'netzkarte_eisenbahninfrastruktur',
+  style: 'netzkarte_eisenbahninfrastruktur_v2',
   properties: {
     hasInfos: true,
     layerInfoComponent: 'InfrastrukturTopicInfo',


### PR DESCRIPTION
# How to

Switch to topic "Netzkarte Eisenbahninfrastruktur", open the network tab: netzkarte_eisenbahninfrastruktur_v2 must be loaded instead of netzkarte_eisenbahninfrastruktur

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] The title means something for a human being.
- [x] Labels applied. if it's a release? a hotfix?
