### PR TITLE
Zweitausbildung: Replace link to Karte D

### DIFF
--- a/src/layers/ZweitausbildungAbroadLayer/FeatureCollection.json
+++ b/src/layers/ZweitausbildungAbroadLayer/FeatureCollection.json
@@ -27,7 +27,7 @@
         "title_fr": "Carte D",
         "title_it": "Carta D",
         "title_en": "Map D",
-        "url": "https://sbb.sharepoint.com/teams/526/1775/_layouts/15/DocIdRedir.aspx?ID=T0526-1440065995-55"
+        "url": "https://sbb.sharepoint.com/:b:/t/526/1775/EZSp4zsdrtNKga74VFyzIsUByezlTLgQ_plLnBgM9snVJQ"
       }
     },
     {


### PR DESCRIPTION
# How to

<!--  Please provide a test link and quick description how to see the change -->
- Switch to topic ch.sbb.zweitausbildung (Development button -> change topic)
- Click on the red feature "Karte D"
- A sharepoint link should open (where we do not have access to)

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] IE11 tested.
- [x] The title means something for a human being.
- [x] Labels applied. if it's a release? a hotfix?
