### PR TITLE
Zweitausbildung: Restrict max zoom to 13

### DIFF
--- a/src/config/topics.js
+++ b/src/config/topics.js
@@ -231,6 +231,7 @@ export const tina = {
 export const zweitausbildung = {
   name: 'ch.sbb.zweitausbildung',
   key: 'ch.sbb.zweitausbildung',
+  maxZoom: 13,
   hideInLayerTree: true,
   elements: { ...defaultElements, shareMenu: true, popup: true },
   layers: [


### PR DESCRIPTION
# How to

<!--  Please provide a test link and quick description how to see the change -->
- Switch to topic ch.sbb.zweitausbildung (Development button -> change topic)
- Zoom in until the zooming stops
- The z value in the permalink should be 13

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] IE11 tested.
- [x] The title means something for a human being.
- [x] Labels applied. if it's a release? a hotfix?
