### PR TITLE
Fix handicap overlays (resolved merge conflict for release branch)

### DIFF
--- a/src/config/layers.js
+++ b/src/config/layers.js
@@ -15,6 +15,7 @@ import ZweitausbildungAbroadLayer from '../layers/ZweitausbildungAbroadLayer/Zwe
 import ZweitausbildungPoisLayer from '../layers/ZweitausbildungPoisLayer/ZweitausbildungPoisLayer';
 import ZweitausbildungRoutesLayer from '../layers/ZweitausbildungRoutesLayer/ZweitausbildungRoutesLayer';
 import ZweitausbildungRoutesHighlightLayer from '../layers/ZweitausbildungRoutesHighlightLayer/ZweitausbildungRoutesHighlightLayer';
+import LayerHelper from '../layers/layerHelper';
 
 proj4.defs(
   'EPSG:21781',
@@ -37,29 +38,6 @@ const projectionExtent = [
   -20037508.3428,
   20037508.3428,
   20037508.3428,
-];
-
-const resolutions = [
-  156543.033928,
-  78271.516964,
-  39135.758482,
-  19567.879241,
-  9783.9396205,
-  4891.96981025,
-  2445.98490513,
-  1222.99245256,
-  611.496226281,
-  305.748113141,
-  152.87405657,
-  76.4370282852,
-  38.2185141426,
-  19.1092570713,
-  9.55462853565,
-  4.77731426782,
-  2.38865713391,
-  1.19432856696,
-  0.597164283478,
-  0.298582141739,
 ];
 
 export const dataLayer = new TrafimageMapboxLayer({
@@ -379,8 +357,8 @@ export const gemeindegrenzen = new TrafimageGeoServerWMSLayer({
       },
       tileGrid: new TileGrid({
         extent: projectionExtent,
-        resolutions,
-        matrixIds: resolutions.map((r, i) => `${i}`),
+        resolutions: LayerHelper.getMapResolutions(),
+        matrixIds: LayerHelper.getMapResolutions().map((r, i) => `${i}`),
       }),
     }),
   }),
@@ -401,8 +379,8 @@ export const parks = new TrafimageGeoServerWMSLayer({
       },
       tileGrid: new TileGrid({
         extent: projectionExtent,
-        resolutions,
-        matrixIds: resolutions.map((r, i) => `${i}`),
+        resolutions: LayerHelper.getMapResolutions(),
+        matrixIds: LayerHelper.getMapResolutions().map((r, i) => `${i}`),
       }),
     }),
     opacity: 0.9,
@@ -848,8 +826,8 @@ export const zweitausbildungStations = new Layer({
           },
           tileGrid: new TileGrid({
             extent: projectionExtent,
-            resolutions,
-            matrixIds: resolutions.map((r, i) => `${i}`),
+            resolutions: LayerHelper.getMapResolutions(),
+            matrixIds: LayerHelper.getMapResolutions().map((r, i) => `${i}`),
           }),
         }),
       }),
@@ -888,8 +866,8 @@ export const zweitausbildungStations = new Layer({
           },
           tileGrid: new TileGrid({
             extent: projectionExtent,
-            resolutions,
-            matrixIds: resolutions.map((r, i) => `${i}`),
+            resolutions: LayerHelper.getMapResolutions(),
+            matrixIds: LayerHelper.getMapResolutions().map((r, i) => `${i}`),
           }),
         }),
       }),

--- a/src/layers/HandicapLayer/HandicapLayer.js
+++ b/src/layers/HandicapLayer/HandicapLayer.js
@@ -84,18 +84,14 @@ class HandicapLayer extends VectorLayer {
    * @returns {Object|null}
    */
   style(feature, resolution) {
-    let geometry = feature.getGeometry();
-    let gen = 100;
-    gen = resolution < 500 ? 30 : gen;
-    gen = resolution < 200 ? 10 : gen;
-    gen = resolution < 100 ? null : gen;
+    const gen = LayerHelper.getMapboxGeneralization(resolution);
+    const wkt = (feature.get('generalizations') || {})[`geom_gen${gen}`];
+    const geometry = wkt
+      ? this.wktFormat.readGeometry(wkt.split(';')[1])
+      : null;
 
-    if (gen) {
-      const wkt = (feature.get('generalizations') || {})[`geom_gen${gen}`];
-      geometry = wkt ? this.wktFormat.readGeometry(wkt.split(';')[1]) : null;
-    }
+    const minVisibility = LayerHelper.getMapboxDataResolution(resolution) * 10;
 
-    const minVisibility = LayerHelper.getDataResolution(resolution) * 10;
     if (!geometry || feature.get('visibility') < minVisibility) {
       return null;
     }

--- a/src/layers/layerHelper.js
+++ b/src/layers/layerHelper.js
@@ -1,3 +1,35 @@
+// Map resolutions by zoom (array index)
+const mapResolutions = [
+  156543.033928,
+  78271.516964,
+  39135.758482,
+  19567.879241,
+  9783.9396205,
+  4891.96981025,
+  2445.98490513,
+  1222.99245256,
+  611.496226281,
+  305.748113141,
+  152.87405657,
+  76.4370282852,
+  38.2185141426,
+  19.1092570713,
+  9.55462853565,
+  4.77731426782,
+  2.38865713391,
+  1.19432856696,
+  0.597164283478,
+  0.298582141739,
+];
+
+/**
+ * Get the map resolutions
+ * where the array index is the zoom level
+ */
+function getMapResolutions() {
+  return mapResolutions;
+}
+
 const dataResolutions = [750, 500, 250, 100, 75, 50, 20, 10, 5];
 
 function getDataResolution(resolution, resolutions = dataResolutions) {
@@ -8,11 +40,11 @@ function getDataResolution(resolution, resolutions = dataResolutions) {
   });
 }
 
-function getGeneralization(resolution, resolutions, generalisations) {
+function getGeneralization(resolution, resolutions, generalizations) {
   const res = getDataResolution(resolution, resolutions);
 
   return (
-    (generalisations || {
+    (generalizations || {
       750: 5,
       500: 10,
       250: 30,
@@ -28,4 +60,80 @@ function getOldGeneralization(resolution) {
   return { 750: 10, 500: 10, 250: 30, 100: 30 }[res] || 100;
 }
 
-export default { getDataResolution, getGeneralization, getOldGeneralization };
+const mapboxDataResolutions = [
+  4500, // zoom 0
+  4500, // zoom 1
+  4500, // etc.
+  4500,
+  4500,
+  4500,
+  1500,
+  500,
+  250,
+  100,
+  50,
+  20,
+  10,
+  5,
+  5,
+  5,
+  5,
+  5,
+  5,
+  5, // zoom 19
+];
+
+/**
+ * Get the data resolution for mapbox layers
+ *
+ * Considers the zoom level substraction for mapbox
+ * and the new data resolutions (e.g. 4500, 3000, 1500)
+ */
+function getMapboxDataResolution(resolution) {
+  const mapRes = mapResolutions.reduce((prev, curr) =>
+    Math.abs(curr - resolution) < Math.abs(prev - resolution) ? curr : prev,
+  );
+
+  // Substract one zoom level
+  // as it is also done in the MapboxLayer in react-spatial (why?)
+  // see jumpTo in render()
+  // see https://github.com/geops/react-spatial/blob/939d9d2535f44b1086e10a187fbb5dc800ae3336/src/layers/MapboxLayer.js#L54
+  let mapboxZoom = mapResolutions.indexOf(mapRes) - 1;
+  if (mapboxZoom < 0) {
+    mapboxZoom = 0;
+  }
+
+  return mapboxDataResolutions[mapboxZoom];
+}
+
+/**
+ * Get the data generalization level for mapbox layers
+ *
+ * Considers the zoom level substraction for mapbox
+ * and the new data resolutions (e.g. 4500, 3000, 1500)
+ */
+function getMapboxGeneralization(resolution) {
+  const res = getMapboxDataResolution(resolution);
+
+  return (
+    {
+      4500: 5,
+      3000: 5,
+      1500: 5,
+      500: 10,
+      250: 30,
+      100: 30,
+      50: 100,
+      20: 100,
+    }[res] || 150
+  );
+}
+
+export default {
+  getMapResolutions,
+  getDataResolution,
+  getGeneralization,
+  getOldGeneralization,
+  getMapboxDataResolution,
+  getMapboxGeneralization,
+};


### PR DESCRIPTION
Merge changes of https://github.com/geops/trafimage-maps/pull/573 into the relase branch
(resolved merge conflict)

# How to

<!--  Please provide a test link and quick description how to see the change -->
switch to handicap topic and compare if the orange points fit to the basemap
(In zoom 9 and others some stations of the basemap are not displayed)

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] IE11 tested.
- [x] The title means something for a human being.
- [x] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
