### PR TITLE
Zweitausbildung: Replace link to Karte D (merge into release branch)

### DIFF
--- a/src/layers/ZweitausbildungAbroadLayer/FeatureCollection.json
+++ b/src/layers/ZweitausbildungAbroadLayer/FeatureCollection.json
@@ -27,7 +27,7 @@
         "title_fr": "Carte D",
         "title_it": "Carta D",
         "title_en": "Map D",
-        "url": "https://sbb.sharepoint.com/teams/526/1775/_layouts/15/DocIdRedir.aspx?ID=T0526-1440065995-55"
+        "url": "https://sbb.sharepoint.com/:b:/t/526/1775/EZSp4zsdrtNKga74VFyzIsUByezlTLgQ_plLnBgM9snVJQ"
       }
     },
     {


### PR DESCRIPTION
Forgot to merge into the release branch first

see https://github.com/geops/trafimage-maps/pull/657/