### PR TITLE
Set apiKey for layers in TopicLoader...

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "react-shadow": "^17.6.0",
     "react-spatial": "0.2.14",
     "react-styleguidist": "^11.0.4",
-    "react-transit": "^0.3.2-beta.1",
+    "react-transit": "^0.3.2",
     "react-web-component": "^2.0.1",
     "redux": "^4.0.5",
     "redux-debounced": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "react-shadow": "^17.6.0",
     "react-spatial": "0.2.14",
     "react-styleguidist": "^11.0.4",
-    "react-transit": "^0.3.1",
+    "react-transit": "^0.3.2-beta.1",
     "react-web-component": "^2.0.1",
     "redux": "^4.0.5",
     "redux-debounced": "^0.5.0",

--- a/src/components/TopicLoader/TopicLoader.js
+++ b/src/components/TopicLoader/TopicLoader.js
@@ -118,7 +118,7 @@ class TopicLoader extends Component {
       this.updateServices(activeTopic);
     }
 
-    if (language !== prevProps.language) {
+    if (language !== prevProps.language || apiKey !== prevProps.apiKey) {
       this.updateLayers(activeTopic.layers);
     }
   }
@@ -217,6 +217,7 @@ class TopicLoader extends Component {
 
   updateLayers(topicLayers) {
     const {
+      apiKey,
       language,
       layerService,
       dispatchSetLayers,
@@ -271,6 +272,15 @@ class TopicLoader extends Component {
       }
       if (flatLayers[i].setStaticFilesUrl) {
         flatLayers[i].setStaticFilesUrl(staticFilesUrl);
+      }
+
+      if (
+        apiKey &&
+        flatLayers[i].setApiKey &&
+        flatLayers[i].getApiKey &&
+        !flatLayers[i].getApiKey()
+      ) {
+        flatLayers[i].setApiKey(apiKey);
       }
     }
   }

--- a/src/config/topics.js
+++ b/src/config/topics.js
@@ -260,10 +260,6 @@ const topics = {
 };
 
 export const getTopicConfig = (apiKey, name) => {
-  punctuality.getChildren().forEach((layer) => {
-    // eslint-disable-next-line no-param-reassign
-    layer.apiKey = apiKey;
-  });
   return topics[name];
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13294,10 +13294,10 @@ react-themeable@^1.1.0:
   dependencies:
     object-assign "^3.0.0"
 
-react-transit@^0.3.2-beta.1:
-  version "0.3.2-beta.1"
-  resolved "https://registry.yarnpkg.com/react-transit/-/react-transit-0.3.2-beta.1.tgz#1b7f3b9958b9de8cfd623f57ebb29a1a3e0d9f89"
-  integrity sha512-wuyxmaRXu9LV69RyHgUHFWIRxBBH/2yPKUrcSmypel12u9GGQ2Y0RVplzNJg5HloVdkxXKe3JYiuuxE/Yc59Jg==
+react-transit@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/react-transit/-/react-transit-0.3.2.tgz#3a48b62d8529f65cdf84fe106c75df7e61dc129c"
+  integrity sha512-THsWrel+uvmJ8ckJveJEhABzCQM17Mktu3vXCdzbbjuq3RffjKG/G65UYVJYiSauUKnL10L81arg82f9oVn1Pw==
   dependencies:
     abortcontroller-polyfill "^1.4.0"
     query-string "^6.11.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12908,6 +12908,18 @@ react-app-rewired@^2.1.5:
   dependencies:
     semver "^5.6.0"
 
+react-autosuggest@^10.0.0:
+  version "10.0.2"
+  resolved "https://registry.yarnpkg.com/react-autosuggest/-/react-autosuggest-10.0.2.tgz#c45cd73a7307026c932cb6a3e19c2fe35bfb6ec4"
+  integrity sha512-ouI0RJDSgM1FBfK0ZmLC3qUqithIwPVTpnC4JQW4DeId3mH2JnZmkNNDKImhcMrxLbSQRpV/DfTLn0uCs4b27w==
+  dependencies:
+    es6-promise "^4.2.8"
+    prop-types "^15.7.2"
+    react-autowhatever "^10.2.1"
+    react-themeable "^1.1.0"
+    section-iterator "^2.0.0"
+    shallow-equal "^1.2.1"
+
 react-autosuggest@^9.4.3:
   version "9.4.3"
   resolved "https://registry.yarnpkg.com/react-autosuggest/-/react-autosuggest-9.4.3.tgz#eb46852422a48144ab9f39fb5470319222f26c7c"
@@ -12917,7 +12929,7 @@ react-autosuggest@^9.4.3:
     react-autowhatever "^10.1.2"
     shallow-equal "^1.0.0"
 
-react-autowhatever@^10.1.2:
+react-autowhatever@^10.1.2, react-autowhatever@^10.2.1:
   version "10.2.1"
   resolved "https://registry.yarnpkg.com/react-autowhatever/-/react-autowhatever-10.2.1.tgz#a6d421dc6135173efedc249ab7216e4f5b691bcc"
   integrity sha512-5gQyoETyBH6GmuW1N1J81CuoAV+Djeg66DEo03xiZOl3WOwJHBP5LisKUvCGOakjrXU4M3hcIvCIqMBYGUmqOA==
@@ -13282,14 +13294,14 @@ react-themeable@^1.1.0:
   dependencies:
     object-assign "^3.0.0"
 
-react-transit@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/react-transit/-/react-transit-0.3.1.tgz#a420788f1244e02eb3d829358d9c53a5e5b83bdf"
-  integrity sha512-yCsRKNwd1k0NsZFkKpAzwKMnbnxQeohYQVUYMrcugXbdhBPcE4t7K0gC8LJceYNWo4IH+v+DkJ3h/yyP7WjhgQ==
+react-transit@^0.3.2-beta.1:
+  version "0.3.2-beta.1"
+  resolved "https://registry.yarnpkg.com/react-transit/-/react-transit-0.3.2-beta.1.tgz#1b7f3b9958b9de8cfd623f57ebb29a1a3e0d9f89"
+  integrity sha512-wuyxmaRXu9LV69RyHgUHFWIRxBBH/2yPKUrcSmypel12u9GGQ2Y0RVplzNJg5HloVdkxXKe3JYiuuxE/Yc59Jg==
   dependencies:
     abortcontroller-polyfill "^1.4.0"
     query-string "^6.11.1"
-    react-autosuggest "^9.4.3"
+    react-autosuggest "^10.0.0"
     react-icons "^3.7.0"
 
 react-use@^13.22.4:
@@ -14511,7 +14523,7 @@ shallow-clone@^3.0.0:
   dependencies:
     kind-of "^6.0.2"
 
-shallow-equal@^1.0.0:
+shallow-equal@^1.0.0, shallow-equal@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/shallow-equal/-/shallow-equal-1.2.1.tgz#4c16abfa56043aa20d050324efa68940b0da79da"
   integrity sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA==


### PR DESCRIPTION
...This fixes the bug where the apiKey was not set for the punctuality layers (TrajservLayer)
when the existing topics where used without calling getTopicConfig() again
(see WebComponent.js line 174).

For the complete bugfix, please use the latest react-transit version
with getter/setter for apiKey.

# How to

<!--  Please provide a test link and quick description how to see the change -->

1. Checkout this branch and create a build
2. Checkout trafimage-maps from GitLab and add this build 
3. Run the application
4. Open the developer tools
5. Make the punctuality layer visible
6. Check if the trajectory_collection request in the Network tab has a valid apiKey, e.g.
`https://api.geops.io/tracker/v1/trajectory_collection?...&key=5cc...a9aa400`,
`https://api.geops.io/tracker/v1/trajectory_collection?...&key=undefined` is not allowed (was the bug).

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [ ] IE11 tested. - Not possible
- [ ] The title means something for a human being.
- [x] The title contains [WIP] if it's necessary.
- [x] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
