### PR TITLE
Handicap popup: Restrict links to max width and use text-overflow ellipsis

### DIFF
--- a/src/popups/HandicapPopup/HandicapPopup.scss
+++ b/src/popups/HandicapPopup/HandicapPopup.scss
@@ -6,6 +6,18 @@
     text-decoration: underline;
   }
 
+  a.wkp-link {
+    text-decoration: none !important;
+  }
+
+  .wkp-link span {
+    text-decoration: underline;
+    text-overflow: ellipsis;
+    max-width: 380px;
+    overflow: hidden;
+    display: inline-block;
+  }
+
   .wkp-handicap-popup-body {
     .wkp-handicap-popup-title {
       font-weight: bold;

--- a/src/popups/HandicapPopup/HandicapPopup.scss
+++ b/src/popups/HandicapPopup/HandicapPopup.scss
@@ -18,6 +18,10 @@
     display: inline-block;
   }
 
+  .wkp-link svg {
+    height: 16px;
+  }
+
   .wkp-handicap-popup-body {
     .wkp-handicap-popup-title {
       font-weight: bold;


### PR DESCRIPTION
# How to

<!--  Please provide a test link and quick description how to see the change -->

1. Open topic handicap
2. Open popup for Bern
3. The long link should overlap the popup border. Instead text-overflow ellipsis is used (...)
4. Other links in this popup should be displayed as before.

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] IE11 tested.
- [x] The title means something for a human being.
- [x] Labels applied. if it's a release? a hotfix?
- [ ] Tests added. - I think, not needed.
