### PR TITLE
Fix baselayer style filter for netzkarte v3

### DIFF
--- a/src/components/TopicLoader/TopicLoader.js
+++ b/src/components/TopicLoader/TopicLoader.js
@@ -133,7 +133,7 @@ class TopicLoader extends Component {
       dispatchSetActiveTopic,
     } = this.props;
 
-    // Load onl ytopics when permissions are loaded, to avoid double loading.
+    // Load only topics when permissions are loaded, to avoid double loading.
     if (!topics.length) {
       return;
     }

--- a/src/config/layers.js
+++ b/src/config/layers.js
@@ -138,7 +138,7 @@ export const swisstopoLandeskarte = new MapboxStyleLayer({
   visible: false,
   mapboxLayer: dataLayer,
   styleLayersFilter: (styleLayer) => {
-    return /pixelkarte_farbe/.test(styleLayer.id);
+    return /img_PK_farbe/.test(styleLayer.id);
   },
 });
 
@@ -150,7 +150,7 @@ export const swisstopoLandeskarteGrau = new MapboxStyleLayer({
   visible: false,
   mapboxLayer: dataLayer,
   styleLayersFilter: (styleLayer) => {
-    return /pixelkarte_grau/.test(styleLayer.id);
+    return /img_PK_grau/.test(styleLayer.id);
   },
 });
 


### PR DESCRIPTION
# How to
Landeskarte & Landeskarte.grau were not visible anymore.
This Pull Request fix it.

<!--  Please provide a test link and quick description how to see the change -->

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] IE11 tested.
- [x] The title means something for a human being.
- [x] The title contains [WIP] if it's necessary.
- [x] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
