### PR TITLE
Use react-spatial v0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react-icons": "^3.9.0",
     "react-redux": "^7.2.0",
     "react-shadow": "^17.6.0",
-    "react-spatial": "^0.3.0-beta.1",
+    "react-spatial": "^0.3.0",
     "react-styleguidist": "^11.0.4",
     "react-transit": "^0.3.3",
     "react-web-component": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react-icons": "^3.9.0",
     "react-redux": "^7.2.0",
     "react-shadow": "^17.6.0",
-    "react-spatial": "0.2.14",
+    "react-spatial": "../react-spatial/build",
     "react-styleguidist": "^11.0.4",
     "react-transit": "^0.3.3",
     "react-web-component": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react-icons": "^3.9.0",
     "react-redux": "^7.2.0",
     "react-shadow": "^17.6.0",
-    "react-spatial": "../react-spatial/build",
+    "react-spatial": "^0.3.0-beta.1",
     "react-styleguidist": "^11.0.4",
     "react-transit": "^0.3.3",
     "react-web-component": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react-icons": "^3.9.0",
     "react-redux": "^7.2.0",
     "react-shadow": "^17.6.0",
-    "react-spatial": "^0.3.0",
+    "react-spatial": "^0.3.1",
     "react-styleguidist": "^11.0.4",
     "react-transit": "^0.3.3",
     "react-web-component": "^2.0.1",

--- a/src/components/TopicLoader/TopicLoader.js
+++ b/src/components/TopicLoader/TopicLoader.js
@@ -119,7 +119,9 @@ class TopicLoader extends Component {
     }
 
     if (language !== prevProps.language || apiKey !== prevProps.apiKey) {
-      this.updateLayers(activeTopic.layers);
+      if (activeTopic) {
+        this.updateLayers(activeTopic.layers);
+      }
     }
   }
 

--- a/src/components/TopicLoader/TopicLoader.js
+++ b/src/components/TopicLoader/TopicLoader.js
@@ -107,21 +107,22 @@ class TopicLoader extends Component {
     }
 
     if (
-      vectorTilesUrl !== prevProps.vectorTilesUrl ||
-      apiKey !== prevProps.apiKey ||
-      vectorTilesKey !== prevProps.vectorTilesKey ||
-      vectorTilesUrl !== prevProps.vectorTilesUrl ||
-      cartaroUrl !== prevProps.cartaroUrl ||
-      appBaseUrl !== prevProps.appBaseUrl ||
-      staticFilesUrl !== prevProps.staticFilesUrl
+      activeTopic &&
+      (vectorTilesUrl !== prevProps.vectorTilesUrl ||
+        apiKey !== prevProps.apiKey ||
+        vectorTilesKey !== prevProps.vectorTilesKey ||
+        cartaroUrl !== prevProps.cartaroUrl ||
+        appBaseUrl !== prevProps.appBaseUrl ||
+        staticFilesUrl !== prevProps.staticFilesUrl)
     ) {
       this.updateServices(activeTopic);
     }
 
-    if (language !== prevProps.language || apiKey !== prevProps.apiKey) {
-      if (activeTopic) {
-        this.updateLayers(activeTopic.layers);
-      }
+    if (
+      activeTopic &&
+      (language !== prevProps.language || apiKey !== prevProps.apiKey)
+    ) {
+      this.updateLayers(activeTopic.layers);
     }
   }
 

--- a/src/config/layers.js
+++ b/src/config/layers.js
@@ -109,7 +109,9 @@ export const netzkarteLayer = new MapboxStyleLayer({
   name: 'ch.sbb.netzkarte',
   copyright: '© OpenStreetMap contributors, OpenMapTiles, imagico, SBB/CFF/FFS',
   isBaseLayer: true,
-  radioGroup: 'baseLayer',
+  properties: {
+    radioGroup: 'baseLayer',
+  },
   visible: true,
   mapboxLayer: dataLayer,
   styleLayersFilter: () => {
@@ -122,7 +124,9 @@ export const swisstopoSwissImage = new MapboxStyleLayer({
   key: 'ch.sbb.netzkarte.luftbild.group',
   copyright: 'swisstopo (5704003351)',
   isBaseLayer: true,
-  radioGroup: 'baseLayer',
+  properties: {
+    radioGroup: 'baseLayer',
+  },
   visible: false,
   mapboxLayer: dataLayer,
   styleLayersFilter: (styleLayer) => {
@@ -134,7 +138,9 @@ export const swisstopoLandeskarte = new MapboxStyleLayer({
   name: 'ch.sbb.netzkarte.landeskarte',
   copyright: 'swisstopo (5704003351)',
   isBaseLayer: true,
-  radioGroup: 'baseLayer',
+  properties: {
+    radioGroup: 'baseLayer',
+  },
   visible: false,
   mapboxLayer: dataLayer,
   styleLayersFilter: (styleLayer) => {
@@ -146,7 +152,9 @@ export const swisstopoLandeskarteGrau = new MapboxStyleLayer({
   name: 'ch.sbb.netzkarte.landeskarte.grau',
   copyright: 'swisstopo (5704003351)',
   isBaseLayer: true,
-  radioGroup: 'baseLayer',
+  properties: {
+    radioGroup: 'baseLayer',
+  },
   visible: false,
   mapboxLayer: dataLayer,
   styleLayersFilter: (styleLayer) => {
@@ -203,7 +211,6 @@ export const bahnhofplaene = new Layer({
 bahnhofplaene.setChildren([
   new MapboxStyleLayer({
     name: 'ch.sbb.bahnhofplaene.interaktiv',
-    radioGroup: 'bahnhofplaene',
     visible: false,
     mapboxLayer: dataLayer,
     styleLayer: {
@@ -221,11 +228,11 @@ bahnhofplaene.setChildren([
       hasInfos: true,
       description: 'ch.sbb.bahnhofplaene.interaktiv-desc',
       popupComponent: 'BahnhofplanPopup',
+      radioGroup: 'bahnhofplaene',
     },
   }),
   new MapboxStyleLayer({
     name: 'ch.sbb.bahnhofplaene.printprodukte',
-    radioGroup: 'bahnhofplaene',
     visible: false,
     mapboxLayer: dataLayer,
     styleLayer: {
@@ -247,6 +254,7 @@ bahnhofplaene.setChildren([
       hasInfos: true,
       description: 'ch.sbb.bahnhofplaene.printprodukte-desc',
       popupComponent: 'BahnhofplanPopup',
+      radioGroup: 'bahnhofplaene',
     },
   }),
 ]);
@@ -275,21 +283,27 @@ punctuality.setChildren([
     name: 'ch.sbb.puenktlichkeit-nv',
     visible: false,
     useDelayStyle: true,
-    radioGroup: 'ch.sbb.punctuality',
     regexPublishedLineName: '^(S|R$|RE|PE|D|IRE|RB|TER)',
+    properties: {
+      radioGroup: 'ch.sbb.punctuality',
+    },
   }),
   new TrajservLayer({
     name: 'ch.sbb.puenktlichkeit-fv',
     visible: false,
     useDelayStyle: true,
-    radioGroup: 'ch.sbb.punctuality',
     regexPublishedLineName: '(IR|IC|EC|RJX|TGV)',
+    properties: {
+      radioGroup: 'ch.sbb.punctuality',
+    },
   }),
   new TrajservLayer({
     name: 'ch.sbb.puenktlichkeit-all',
     visible: false,
     useDelayStyle: true,
-    radioGroup: 'ch.sbb.punctuality',
+    properties: {
+      radioGroup: 'ch.sbb.punctuality',
+    },
   }),
 ]);
 
@@ -407,13 +421,13 @@ export const netzkarteShowcasesNight = new TrafimageMapboxLayer({
   name: 'ch.sbb.netzkarte.night',
   copyright: '© OpenStreetMap contributors, OpenMapTiles, imagico, SBB/CFF/FFS',
   visible: false,
-  radioGroup: 'showcases',
   preserveDrawingBuffer: true,
   zIndex: -1, // Add zIndex as the MapboxLayer would block tiled layers (buslines)
   style: 'showcase2',
   properties: {
     hasInfos: true,
     description: 'ch.sbb.netzkarte.night-desc',
+    radioGroup: 'showcases',
   },
 });
 
@@ -421,13 +435,13 @@ export const netzkarteShowcasesLight = new TrafimageMapboxLayer({
   name: 'ch.sbb.netzkarte.light',
   copyright: '© OpenStreetMap contributors, OpenMapTiles, imagico, SBB/CFF/FFS',
   visible: false,
-  radioGroup: 'showcases',
   preserveDrawingBuffer: true,
   zIndex: -1, // Add zIndex as the MapboxLayer would block tiled layers (buslines)
   style: 'showcase3',
   properties: {
     hasInfos: true,
     description: 'ch.sbb.netzkarte.light-desc',
+    radioGroup: 'showcases',
   },
 });
 
@@ -436,13 +450,13 @@ export const netzkarteShowcasesNetzkarte = new TrafimageMapboxLayer({
   copyright: '© OpenStreetMap contributors, OpenMapTiles, imagico, SBB/CFF/FFS',
   visible: true,
   isQueryable: false,
-  radioGroup: 'showcases',
   preserveDrawingBuffer: true,
   zIndex: -1, // Add zIndex as the MapboxLayer would block tiled layers (buslines)
   style: 'netzkarte_personenverkehr',
   properties: {
     hasInfos: true,
     description: 'ch.sbb.netzkarte-desc',
+    radioGroup: 'showcases',
   },
 });
 
@@ -708,7 +722,6 @@ export const grenzen = new Layer({
       children: [
         new MapboxStyleLayer({
           name: 'ch.sbb.infrastruktur.gemeindegrenzen.greengrenzen',
-          radioGroup: 'ch.sbb.infrastruktur.gemeindegrenzen.group',
           visible: false,
           mapboxLayer: netzkarteEisenbahninfrastruktur,
           styleLayersFilter: (styleLayer) => {
@@ -719,11 +732,11 @@ export const grenzen = new Layer({
           properties: {
             hasInfos: true,
             description: 'ch.sbb.infrastruktur.gemeindegrenzen.greengrenzen',
+            radioGroup: 'ch.sbb.infrastruktur.gemeindegrenzen.group',
           },
         }),
         new MapboxStyleLayer({
           name: 'ch.sbb.infrastruktur.gemeindegrenzen.greygrenzen',
-          radioGroup: 'ch.sbb.infrastruktur.gemeindegrenzen.group',
           visible: false,
           mapboxLayer: netzkarteEisenbahninfrastruktur,
           styleLayersFilter: (styleLayer) => {
@@ -734,6 +747,7 @@ export const grenzen = new Layer({
           properties: {
             hasInfos: true,
             description: 'ch.sbb.infrastruktur.gemeindegrenzen.greygrenzen',
+            radioGroup: 'ch.sbb.infrastruktur.gemeindegrenzen.group',
           },
         }),
       ],
@@ -748,7 +762,6 @@ export const grenzen = new Layer({
       children: [
         new MapboxStyleLayer({
           name: 'ch.sbb.infrastruktur.kantonsgrenzen.greengrenzen',
-          radioGroup: 'ch.sbb.infrastruktur.kantonsgrenzen.group',
           visible: false,
           mapboxLayer: netzkarteEisenbahninfrastruktur,
           styleLayersFilter: (styleLayer) => {
@@ -757,11 +770,11 @@ export const grenzen = new Layer({
           properties: {
             hasInfos: true,
             description: 'ch.sbb.infrastruktur.kantonsgrenzen.greengrenzen',
+            radioGroup: 'ch.sbb.infrastruktur.kantonsgrenzen.group',
           },
         }),
         new MapboxStyleLayer({
           name: 'ch.sbb.infrastruktur.kantonsgrenzen.greygrenzen',
-          radioGroup: 'ch.sbb.infrastruktur.kantonsgrenzen.group',
           visible: false,
           mapboxLayer: netzkarteEisenbahninfrastruktur,
           styleLayersFilter: (styleLayer) => {
@@ -772,6 +785,7 @@ export const grenzen = new Layer({
           properties: {
             hasInfos: true,
             description: 'ch.sbb.infrastruktur.kantonsgrenzen.greygrenzen',
+            radioGroup: 'ch.sbb.infrastruktur.kantonsgrenzen.group',
           },
         }),
       ],
@@ -976,7 +990,6 @@ export const zweitausbildungRoutes = new Layer({
       key: 'ch.sbb.zweitausbildung.tourist.routes.group',
       visible: false,
       isAlwaysExpanded: true,
-      radioGroup: 'zweitausbildungRoutes',
       properties: {
         hasInfos: true,
         layerInfoComponent: 'ZweitausbildungRoutesSubLayerInfo',
@@ -990,6 +1003,7 @@ export const zweitausbildungRoutes = new Layer({
           },
           layer: 'zweitausbildung_tourist_strecken_grouped_qry',
         },
+        radioGroup: 'zweitausbildungRoutes',
       },
       children: [
         new ZweitausbildungRoutesHighlightLayer({
@@ -1012,7 +1026,6 @@ export const zweitausbildungRoutes = new Layer({
       key: 'ch.sbb.zweitausbildung.hauptlinien.group',
       visible: true,
       isAlwaysExpanded: true,
-      radioGroup: 'zweitausbildungRoutes',
       properties: {
         hasInfos: true,
         layerInfoComponent: 'ZweitausbildungRoutesSubLayerInfo',
@@ -1026,6 +1039,7 @@ export const zweitausbildungRoutes = new Layer({
           },
           layer: 'zweitausbildung_hauptlinien_grouped_qry',
         },
+        radioGroup: 'zweitausbildungRoutes',
       },
       children: [
         new ZweitausbildungRoutesHighlightLayer({

--- a/src/examples/Casa/topic.js
+++ b/src/examples/Casa/topic.js
@@ -38,9 +38,11 @@ const netzkarteLayer = new TrafimageMapboxLayer({
   name: 'ch.sbb.netzkarte',
   copyright: '© OpenStreetMap contributors, OpenMapTiles, imagico, SBB/CFF/FFS',
   visible: true,
-  radioGroup: 'baseLayer',
   isBaseLayer: true,
   style: 'netzkarte_personenverkehr_v3',
+  properties: {
+    radioGroup: 'baseLayer',
+  },
 });
 
 // Remove all symbols and circl styles
@@ -75,17 +77,18 @@ const netzkarteShowcasesLight = new TrafimageMapboxLayer({
   name: 'ch.sbb.netzkarte.light',
   copyright: '© OpenStreetMap contributors, OpenMapTiles, imagico, SBB/CFF/FFS',
   visible: true,
-  radioGroup: 'baseLayer',
   isBaseLayer: true,
   preserveDrawingBuffer: true,
   zIndex: -1, // Add zIndex as the MapboxLayer would block tiled layers (buslines)
   style: 'showcase3',
+  properties: {
+    radioGroup: 'baseLayer',
+  },
 });
 
 const swisstopoSwissImage = new Layer({
   name: 'ch.sbb.netzkarte.luftbild',
   copyright: 'swisstopo (5704003351)',
-  radioGroup: 'baseLayer',
   isBaseLayer: true,
   visible: false,
   olLayer: new TileLayer({
@@ -106,6 +109,9 @@ const swisstopoSwissImage = new Layer({
       }),
     }),
   }),
+  properties: {
+    radioGroup: 'baseLayer',
+  },
 });
 
 export default {

--- a/src/examples/Punctuality/layers.js
+++ b/src/examples/Punctuality/layers.js
@@ -41,10 +41,12 @@ export const netzkarteLayer = new TrafimageMapboxLayer({
   visible: true,
   isQueryable: false,
   isBaseLayer: true,
-  radioGroup: 'baseLayer',
   preserveDrawingBuffer: true,
   zIndex: -1, // Add zIndex as the MapboxLayer would block tiled layers (buslines)
   style: 'netzkarte_personenverkehr',
+  properties: {
+    radioGroup: 'baseLayer',
+  },
 });
 
 export const swisstopoSwissImage = new Layer({
@@ -52,7 +54,6 @@ export const swisstopoSwissImage = new Layer({
   key: 'ch.sbb.netzkarte.luftbild.group',
   copyright: 'swisstopo (5704003351)',
   isBaseLayer: true,
-  radioGroup: 'baseLayer',
   visible: false,
   olLayer: new TileLayer({
     source: new WMTSSource({
@@ -72,6 +73,9 @@ export const swisstopoSwissImage = new Layer({
       }),
     }),
   }),
+  properties: {
+    radioGroup: 'baseLayer',
+  },
 });
 
 export const swisstopoLandeskarte = new Layer({
@@ -79,7 +83,6 @@ export const swisstopoLandeskarte = new Layer({
   copyright: 'swisstopo (5704003351)',
   visible: false,
   isBaseLayer: true,
-  radioGroup: 'baseLayer',
   olLayer: new TileLayer({
     source: new WMTSSource({
       url:
@@ -97,6 +100,9 @@ export const swisstopoLandeskarte = new Layer({
       }),
     }),
   }),
+  properties: {
+    radioGroup: 'baseLayer',
+  },
 });
 
 export const swisstopoLandeskarteGrau = new Layer({
@@ -104,7 +110,6 @@ export const swisstopoLandeskarteGrau = new Layer({
   copyright: 'swisstopo (5704003351)',
   visible: false,
   isBaseLayer: true,
-  radioGroup: 'baseLayer',
   olLayer: new TileLayer({
     source: new WMTSSource({
       url:
@@ -123,6 +128,9 @@ export const swisstopoLandeskarteGrau = new Layer({
       }),
     }),
   }),
+  properties: {
+    radioGroup: 'baseLayer',
+  },
 });
 
 export const buslines = new MapboxStyleLayer({

--- a/src/layers/TrafimageGeoServerWMSLayer/TrafimageGeoServerWMSLayer.js
+++ b/src/layers/TrafimageGeoServerWMSLayer/TrafimageGeoServerWMSLayer.js
@@ -1,6 +1,15 @@
 import WMSLayer from 'react-spatial/layers/WMSLayer';
 
 class TrafimageGeoServerWMSLayer extends WMSLayer {
+  constructor(options = {}) {
+    super({
+      ...options,
+    });
+    if (options.zIndex) {
+      this.olLayer.setZIndex(options.zIndex);
+    }
+  }
+
   setGeoServerWMSUrl(geoServerUrl) {
     this.olLayer.getSource().setUrl(geoServerUrl);
   }

--- a/src/layers/TrafimageMapboxLayer/TrafimageMapboxLayer.js
+++ b/src/layers/TrafimageMapboxLayer/TrafimageMapboxLayer.js
@@ -10,6 +10,13 @@ class TrafimageMapboxLayer extends MapboxLayer {
         target: this,
       });
     }
+
+    // Set zIndex if specified
+    if (this.options && this.options.zIndex) {
+      this.olLayer
+        .getLayersArray()
+        .forEach((layer) => layer.setZIndex(this.options.zIndex));
+    }
   }
 
   terminate(map) {

--- a/src/layers/ZweitausbildungAbroadLayer/ZweitausbildungAbroadLayer.js
+++ b/src/layers/ZweitausbildungAbroadLayer/ZweitausbildungAbroadLayer.js
@@ -28,6 +28,7 @@ class ZweitausbildungAbroadLayer extends VectorLayer {
           this.olLayer.getSource().addFeatures(features);
         },
       }),
+      zIndex: options.zIndex || 0,
     });
 
     super({

--- a/src/layers/ZweitausbildungPoisLayer/ZweitausbildungPoisLayer.js
+++ b/src/layers/ZweitausbildungPoisLayer/ZweitausbildungPoisLayer.js
@@ -24,6 +24,7 @@ class ZweitausbildungPoisLayer extends VectorLayer {
   constructor(options = {}) {
     const olLayer = new OLVectorLayer({
       style: (f) => this.style(f),
+      zIndex: options.zIndex || 0,
     });
 
     super({

--- a/src/layers/ZweitausbildungRoutesHighlightLayer/ZweitausbildungRoutesHighlightLayer.js
+++ b/src/layers/ZweitausbildungRoutesHighlightLayer/ZweitausbildungRoutesHighlightLayer.js
@@ -34,6 +34,7 @@ class ZweitausbildungRoutesHighlightLayer extends VectorLayer {
       source: new OLVectorSource({
         format: new GeoJSON(),
       }),
+      zIndex: options.zIndex || 0,
     });
 
     super({

--- a/yarn.lock
+++ b/yarn.lock
@@ -13178,10 +13178,8 @@ react-simple-code-editor@^0.10.0:
   resolved "https://registry.yarnpkg.com/react-simple-code-editor/-/react-simple-code-editor-0.10.0.tgz#73e7ac550a928069715482aeb33ccba36efe2373"
   integrity sha512-bL5W5mAxSW6+cLwqqVWY47Silqgy2DKDTR4hDBrLrUqC5BXc29YVx17l2IZk5v36VcDEq1Bszu2oHm1qBwKqBA==
 
-react-spatial@0.2.14:
-  version "0.2.14"
-  resolved "https://registry.yarnpkg.com/react-spatial/-/react-spatial-0.2.14.tgz#2093ebceb57f980d6cb1f53ef786bb02ef6c65a6"
-  integrity sha512-sdxV9vR3IQjYoSejz8vpek6wknRsC/0XI91TfqcahAGCXbqI9pgsaS02Z2wurlpysPifbs5j9kxjMaeW79tWmw==
+react-spatial@../react-spatial/build:
+  version "0.2.19-beta.2"
   dependencies:
     query-string "^6.11.1"
     radians-degrees "^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13178,10 +13178,10 @@ react-simple-code-editor@^0.10.0:
   resolved "https://registry.yarnpkg.com/react-simple-code-editor/-/react-simple-code-editor-0.10.0.tgz#73e7ac550a928069715482aeb33ccba36efe2373"
   integrity sha512-bL5W5mAxSW6+cLwqqVWY47Silqgy2DKDTR4hDBrLrUqC5BXc29YVx17l2IZk5v36VcDEq1Bszu2oHm1qBwKqBA==
 
-react-spatial@^0.3.0-beta.1:
-  version "0.3.0-beta.1"
-  resolved "https://registry.yarnpkg.com/react-spatial/-/react-spatial-0.3.0-beta.1.tgz#dd1efa2f9c24ed16f6c9db92564dd14c344af975"
-  integrity sha512-3wmsnw0m9pqYDIxaYnNBRKlSlyB41sqCcrWRh8pThrFy10OzXf13AVfesTu3QH469kPd01vIcueBGWJaXiPUiQ==
+react-spatial@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/react-spatial/-/react-spatial-0.3.0.tgz#5355172951432a0e17147ce8a943ecc5d037586f"
+  integrity sha512-Wwi3ghSM2LQGF+1eXLwyFnqxY7HRoLZOcIHJgrDVczOyHjEql0klUTy21c83qAiJKa1ekI9k/JUe2tdFzCj2Cg==
   dependencies:
     query-string "^6.11.1"
     radians-degrees "^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13178,8 +13178,10 @@ react-simple-code-editor@^0.10.0:
   resolved "https://registry.yarnpkg.com/react-simple-code-editor/-/react-simple-code-editor-0.10.0.tgz#73e7ac550a928069715482aeb33ccba36efe2373"
   integrity sha512-bL5W5mAxSW6+cLwqqVWY47Silqgy2DKDTR4hDBrLrUqC5BXc29YVx17l2IZk5v36VcDEq1Bszu2oHm1qBwKqBA==
 
-react-spatial@../react-spatial/build:
-  version "0.2.19-beta.2"
+react-spatial@^0.3.0-beta.1:
+  version "0.3.0-beta.1"
+  resolved "https://registry.yarnpkg.com/react-spatial/-/react-spatial-0.3.0-beta.1.tgz#dd1efa2f9c24ed16f6c9db92564dd14c344af975"
+  integrity sha512-3wmsnw0m9pqYDIxaYnNBRKlSlyB41sqCcrWRh8pThrFy10OzXf13AVfesTu3QH469kPd01vIcueBGWJaXiPUiQ==
   dependencies:
     query-string "^6.11.1"
     radians-degrees "^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13178,10 +13178,10 @@ react-simple-code-editor@^0.10.0:
   resolved "https://registry.yarnpkg.com/react-simple-code-editor/-/react-simple-code-editor-0.10.0.tgz#73e7ac550a928069715482aeb33ccba36efe2373"
   integrity sha512-bL5W5mAxSW6+cLwqqVWY47Silqgy2DKDTR4hDBrLrUqC5BXc29YVx17l2IZk5v36VcDEq1Bszu2oHm1qBwKqBA==
 
-react-spatial@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/react-spatial/-/react-spatial-0.3.0.tgz#5355172951432a0e17147ce8a943ecc5d037586f"
-  integrity sha512-Wwi3ghSM2LQGF+1eXLwyFnqxY7HRoLZOcIHJgrDVczOyHjEql0klUTy21c83qAiJKa1ekI9k/JUe2tdFzCj2Cg==
+react-spatial@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/react-spatial/-/react-spatial-0.3.1.tgz#b27551f26ce01e414349fb0d7ca9f4ee6c87c0d6"
+  integrity sha512-6HlXIeoJ2sKiPy1pFwqEaO7Ral/NFb2/nSq09UMxNyty1fFEuh1z+FIsIhc+Z8DpDa3BhJROiAWP1E+qYJm8SQ==
   dependencies:
     query-string "^6.11.1"
     radians-degrees "^1.0.0"


### PR DESCRIPTION
These changes have already reviewed and approved in https://github.com/geops/trafimage-maps/pull/686.

The commits are based on https://github.com/geops/trafimage-maps/pull/680

Merge this PR if the react-spatial version v.0.3.1 is needed.

# How to

<!--  Please provide a test link and quick description how to see the change -->

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] IE11 tested.
- [x] The title means something for a human being.
- [ ] Labels applied. if it's a release? a hotfix?
- [ ] Tests added. - Not needed as these are nearly only cherry-picks
