### PR TITLE
Upgrade react-spatial with Switcher fix 

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react-icons": "^3.9.0",
     "react-redux": "^7.2.0",
     "react-shadow": "^17.6.0",
-    "react-spatial": "^0.3.4",
+    "react-spatial": "0.3.5",
     "react-styleguidist": "^11.0.4",
     "react-transit": "^0.3.3",
     "react-web-component": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13178,10 +13178,10 @@ react-simple-code-editor@^0.10.0:
   resolved "https://registry.yarnpkg.com/react-simple-code-editor/-/react-simple-code-editor-0.10.0.tgz#73e7ac550a928069715482aeb33ccba36efe2373"
   integrity sha512-bL5W5mAxSW6+cLwqqVWY47Silqgy2DKDTR4hDBrLrUqC5BXc29YVx17l2IZk5v36VcDEq1Bszu2oHm1qBwKqBA==
 
-react-spatial@^0.3.4:
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/react-spatial/-/react-spatial-0.3.4.tgz#47fe4c22d88617bdfe8e602237741be86440c7dd"
-  integrity sha512-mn6Bn9m8IyFNQp9kiezdQJWZQsXDEuTBaU3W+psxImUDdsEvH2yYWhbbvceCmk05mrXUyhvJ+TvK/e+gRZZmLQ==
+react-spatial@0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/react-spatial/-/react-spatial-0.3.5.tgz#504d9abcce4b09b12610f72e8c099d4af4bb5d16"
+  integrity sha512-njZnrlvOpD/OE5KB8J+Q4zmomQmBxEI4K6FFHEaUCfykr0cgaMhMB/k3QpazIcRK5xLDMyHIyx53RC1W2oK+zA==
   dependencies:
     query-string "^6.11.1"
     radians-degrees "^1.0.0"


### PR DESCRIPTION
# How to

When switching from a topic with no base layers (e.g. showcases) to a topic with base layers, the switcher can't set the currentLayer and crashes the app. This has been fixed in react-spatial 0.3.5 by adding currentLayer to the main render condition (renders null if currentLayer is undefined).

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [ ] It's not a hack or at least an unauthorized hack :).
- [ ] The images added are optimized.
- [ ] Everything in ticket description has been fixed.
- [ ] The author of the MR has made its own review before assigning the reviewer.
- [ ] IE11 tested.
- [x] The title means something for a human being.
- [x] The title contains [WIP] if it's necessary.
- [x] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
