### PR TITLE
Fix typo in coordinate system name, rename CH1093 to CH1903 etc.

### DIFF
--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -25,12 +25,12 @@ const Footer = () => {
 
   const projections = [
     {
-      label: 'CH1093 / LV03',
+      label: 'CH1903 / LV03',
       value: 'EPSG:21781',
       format: (c) => `${t('Koordinaten')}: ${coordinateHelper.meterFormat(c)}`,
     },
     {
-      label: 'CH1093+ / LV95',
+      label: 'CH1903+ / LV95',
       value: 'EPSG:2056',
       format: (c) => `${t('Koordinaten')}: ${coordinateHelper.meterFormat(c)}`,
     },


### PR DESCRIPTION
See TRAFWART-829

# How to

<!--  Please provide a test link and quick description how to see the change -->
The coordinate system name in the footer (MousePosition component) should be CH1903 instead of CH1093

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] The title means something for a human being.
- [x] Labels applied. if it's a release? a hotfix?
