### PR TITLE
Search bar overlap fix

### DIFF
--- a/src/components/TrafimageMaps/TrafimageMaps.scss
+++ b/src/components/TrafimageMaps/TrafimageMaps.scss
@@ -186,7 +186,6 @@
   &.tm-w-xs {
     .wkp-search {
       min-width: unset;
-      left: 55px;
     }
 
     .wkp-search-toggle-container--open {
@@ -362,6 +361,7 @@
 
     .wkp-search {
       right: 220px;
+      left: 80px;
 
       .wkp-search-toggle-button {
         margin-right: -45px;
@@ -378,6 +378,7 @@
 
     .wkp-search {
       right: 10px;
+      left: 55px;
 
       .wkp-search-toggle-button {
         margin-right: -40px;


### PR DESCRIPTION
# How to

On resolutions between 1200px und 992px (e.g. iPad) the search component container overlaps the menu component when expanded, making it impossible to click the menu. This was caused due to a uniform left: 55px attribute for all mobile devices. The left attribute was adjusted to make it more device responsive.

To test, use the review app and set the resolution to iPad, and other mobile devices and test the menu button while the search bar is expanded

# Others

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] IE11 tested.
- [x] The title means something for a human being.
- [ ] The title contains [WIP] if it's necessary.
- [ ] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
