### PR TITLE
Fix css to only blink the map, when focusing with tab

### DIFF
--- a/src/components/TrafimageMaps/TrafimageMaps.scss
+++ b/src/components/TrafimageMaps/TrafimageMaps.scss
@@ -123,9 +123,11 @@
     left: 0;
   }
 
-  :not(.tm-no-focus) {
-    .rs-map:focus {
-      animation: blink 0.3s linear;
+  .tm-barrier-free {
+    &:not(.tm-no-focus) {
+      .rs-map:focus {
+        animation: blink 0.3s linear;
+      }
     }
   }
 

--- a/src/components/TrafimageMaps/TrafimageMaps.scss
+++ b/src/components/TrafimageMaps/TrafimageMaps.scss
@@ -24,6 +24,14 @@
     }
   }
 
+  .rs-map {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    right: 0;
+    left: 0;
+  }
+
   .tm-barrier-free {
     height: 100%;
     width: 100%;
@@ -38,6 +46,12 @@
 
     &.tm-no-focus *:focus {
       outline: none;
+    }
+
+    &:not(.tm-no-focus) {
+      .rs-map:focus {
+        animation: blink 0.3s linear;
+      }
     }
   }
 
@@ -113,22 +127,6 @@
 
   .wkp-selected {
     color: $brand-primary;
-  }
-
-  .rs-map {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    right: 0;
-    left: 0;
-  }
-
-  .tm-barrier-free {
-    &:not(.tm-no-focus) {
-      .rs-map:focus {
-        animation: blink 0.3s linear;
-      }
-    }
   }
 
   .rs-popup {


### PR DESCRIPTION
# How to

<!--  Please provide a test link and quick description how to see the change -->
Fix css to only blink the map, when focusing with tab (and not on pointermove)

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] IE11 tested.
- [x] The title means something for a human being.
- [x] The title contains [WIP] if it's necessary.
- [x] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
