### PR TITLE
Fix Route onClick bug + add/improve tests

### DIFF
--- a/src/examples/Casa/README.md
+++ b/src/examples/Casa/README.md
@@ -146,7 +146,7 @@ routeLayer
     },
     {
       isClickable: true,
-      isSelected: false,
+      isSelected: true,
       sequences: [
         {
           uicFrom: 8503000,

--- a/src/examples/Casa/README.md
+++ b/src/examples/Casa/README.md
@@ -130,7 +130,7 @@ routeLayer
   .loadRoutes([
     {
       isClickable: true,
-      isSelected: true,
+      isSelected: false,
       popupTitle: 'Route St. Gallen >> Zürich',
       popupContent: {
         Von: 'St. Gallen',

--- a/src/layers/RouteLayer/RouteLayer.js
+++ b/src/layers/RouteLayer/RouteLayer.js
@@ -271,7 +271,7 @@ class RouteLayer extends CasaLayer {
       this.olLayer.getSource().addFeatures(sequenceFeatures);
       sequenceFeatures.forEach((f) => {
         const { routeId, isSelected } = f.get('route');
-        if (isSelected) {
+        if (isSelected && this.selectedRouteIds.indexOf(routeId) === -1) {
           this.selectedRouteIds.push(routeId);
         }
       });

--- a/src/layers/RouteLayer/RouteLayer.test.js
+++ b/src/layers/RouteLayer/RouteLayer.test.js
@@ -76,7 +76,7 @@ const routeDataBus = {
   geometry: {
     type: 'LineString',
     coordinates: [
-      [1, 1],
+      [-1, -1],
       [10, 10],
     ],
   },
@@ -103,8 +103,8 @@ const routeDataBus = {
 
 const feature = new Feature({
   geometry: new LineString([
-    [1, 1],
     [10, 10],
+    [1, 1],
   ]),
   mot: 'rail',
   route: {
@@ -126,6 +126,12 @@ let layer;
 let map;
 let onClick;
 let onMouseOver;
+
+const fetchRoutes = () => {
+  /* Mock fetch for each sequence */
+  fetchMock.once(/8503000/g, routeDataRail);
+  fetchMock.once(/8576579/g, routeDataBus);
+};
 
 describe('RouteLayer', () => {
   beforeEach(() => {
@@ -156,9 +162,7 @@ describe('RouteLayer', () => {
 
   test('should return the correct styles when selected.', async () => {
     layer.init(map);
-    /* Mock fetch for each sequence */
-    fetchMock.once(/8503000/g, routeDataRail);
-    fetchMock.once(/8576579/g, routeDataBus);
+    fetchRoutes();
 
     const [rail, bus] = await layer.loadRoutes(routes);
 
@@ -225,20 +229,15 @@ describe('RouteLayer', () => {
 
   test('should return a feature on loadRoute.', async () => {
     layer.init(map);
-    /* Mock fetch for each sequence */
-    fetchMock.once(/8503000/g, routeDataRail);
-    fetchMock.once(/8576579/g, routeDataBus);
-
+    fetchRoutes();
     const route = await layer.loadRoutes(routes);
 
     expect(route[0]).toBeInstanceOf(Feature);
   });
 
   test('shoud call onClick callbacks and deselect on click.', async () => {
-    const coordinate = [50, 50];
-    /* Mock fetch for each sequence */
-    fetchMock.once(/8503000/g, routeDataRail);
-    fetchMock.once(/8576579/g, routeDataBus);
+    const coordinate = [10, 10];
+    fetchRoutes();
     layer.init(map);
     const features = await layer.loadRoutes(routes);
     jest.spyOn(map, 'getFeaturesAtPixel').mockReturnValue([features[0]]);

--- a/src/layers/RouteLayer/RouteLayer.test.js
+++ b/src/layers/RouteLayer/RouteLayer.test.js
@@ -103,8 +103,8 @@ const routeDataBus = {
 
 const feature = new Feature({
   geometry: new LineString([
-    [50, 50],
-    [50, 10],
+    [1, 1],
+    [10, 10],
   ]),
   mot: 'rail',
   route: {
@@ -223,7 +223,7 @@ describe('RouteLayer', () => {
     );
   });
 
-  test.only('should return a feature on loadRoute.', async () => {
+  test('should return a feature on loadRoute.', async () => {
     layer.init(map);
     /* Mock fetch for each sequence */
     fetchMock.once(/8503000/g, routeDataRail);
@@ -234,18 +234,21 @@ describe('RouteLayer', () => {
     expect(route[0]).toBeInstanceOf(Feature);
   });
 
-  test('shoud call onClick callbacks.', async () => {
+  test('shoud call onClick callbacks and deselect on click.', async () => {
     const coordinate = [50, 50];
+    /* Mock fetch for each sequence */
+    fetchMock.once(/8503000/g, routeDataRail);
+    fetchMock.once(/8576579/g, routeDataBus);
     layer.init(map);
-    jest.spyOn(map, 'getFeaturesAtPixel').mockReturnValue([feature]);
+    const features = await layer.loadRoutes(routes);
+    jest.spyOn(map, 'getFeaturesAtPixel').mockReturnValue([features[0]]);
     jest.spyOn(map, 'forEachLayerAtPixel').mockReturnValue(layer.olLayer);
 
     expect(onClick).toHaveBeenCalledTimes(0);
-
     const evt = { type: 'singleclick', map, coordinate };
     await map.dispatchEvent(evt);
-
-    expect(onClick).toHaveBeenCalledWith([feature], layer, coordinate);
+    expect(onClick).toHaveBeenCalledWith([features[0]], layer, coordinate);
+    expect(layer.selectedRouteIds).toEqual([]);
   });
 
   test('shoud open a popup if popupContent is defined', async () => {
@@ -265,18 +268,4 @@ describe('RouteLayer', () => {
       'Von: St. GallenNach: Zürich HB',
     );
   });
-
-  // test('shoud call onClick callbacks.', async () => {
-  //   const coordinate = [50, 50];
-  //   layer.init(map);
-  //   jest.spyOn(map, 'getFeaturesAtPixel').mockReturnValue([feature]);
-  //   jest.spyOn(map, 'forEachLayerAtPixel').mockReturnValue(layer.olLayer);
-
-  //   expect(onClick).toHaveBeenCalledTimes(0);
-
-  //   const evt = { type: 'singleclick', map, coordinate };
-  //   await map.dispatchEvent(evt);
-
-  //   expect(onClick).toHaveBeenCalledWith([feature], layer, coordinate);
-  // });
 });


### PR DESCRIPTION
# How to

Previously the route id was added to the selectedRoutIds array for every sequence, causing the routeId to be added multiple times, resulting in having to click multiple times to deselect the feature until it is deselected for the first time (since splice was used on the array, removing only one of the identical indices)

This behaviour was prevented by adding a condition to only add the index on load if it is not already present.

Tests were improved to check whether the flag icon is only set on the last sequence and whether the routeId is removed from the selectedRouteIds array on click

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] IE11 tested.
- [x] The title means something for a human being.
- [x] The title contains [WIP] if it's necessary.
- [ ] Labels applied. if it's a release? a hotfix?
- [x] Tests added.
