### PR TITLE
Circle markers on start and end of routes only

### DIFF
--- a/src/layers/RouteLayer/RouteLayer.js
+++ b/src/layers/RouteLayer/RouteLayer.js
@@ -157,9 +157,11 @@ class RouteLayer extends CasaLayer {
             lineStrings.map((l) => l.getGeometry()),
           ),
         });
-        feature.setProperties(sequenceProps);
-        if (isStart) feature.set('start', isStart);
-        if (isEnd) feature.set('end', isEnd);
+        feature.setProperties({
+          ...sequenceProps,
+          isStart,
+          isEnd,
+        });
         return feature;
       });
   }
@@ -177,8 +179,6 @@ class RouteLayer extends CasaLayer {
       this.hoverFeature &&
       (this.hoverFeature.get('route') || {}).isClickable &&
       (this.hoverFeature.get('route') || {}).routeId === routeId;
-    const isStart = feature.get('start');
-    const isEnd = feature.get('end');
 
     const routeStyle = this.styleFunction(
       feature.getProperties(),
@@ -196,10 +196,12 @@ class RouteLayer extends CasaLayer {
       const lineEnd = feature.getGeometry().getLastCoordinate();
 
       /* Set circle icon if it is the first sequence of a route */
-      if (isStart) styleArray.push(RouteLayer.getCircleStyle(lineStart));
+      if (feature.get('isStart')) {
+        styleArray.push(RouteLayer.getCircleStyle(lineStart));
+      }
 
       /* Set flag and circle icons if it is the final sequence of a route */
-      if (isEnd) {
+      if (feature.get('isEnd')) {
         styleArray.push(RouteLayer.getCircleStyle(lineEnd));
         styleArray.push(
           new Style({

--- a/src/layers/RouteLayer/RouteLayer.test.js
+++ b/src/layers/RouteLayer/RouteLayer.test.js
@@ -169,13 +169,15 @@ describe('RouteLayer', () => {
     const styleRail = layer.routeStyle(rail);
     const styleBus = layer.routeStyle(bus);
 
-    /* Bus sequence should return an additional style (flag icon) because it is the last sequence */
-    expect(styleRail).toHaveLength(3);
-    expect(styleBus).toHaveLength(4);
+    /* Circle markers should render at the first coordinate of the rail sequence and at the last coordinate
+     * of the bus sequence. Bus sequence should return an additional style (flag icon) because it is the last sequence.
+     */
+    expect(styleRail).toHaveLength(2);
+    expect(styleBus).toHaveLength(3);
 
-    [rail, bus].forEach(() => {
-      expect(styleRail[0].getZIndex()).toEqual(0.5);
-      expect(styleRail[1].getImage()).toEqual(
+    [styleRail, styleBus].forEach((styles) => {
+      expect(styles[0].getZIndex()).toEqual(0.5);
+      expect(styles[1].getImage()).toEqual(
         new Circle({
           radius: 3,
           fill: new Fill({
@@ -189,7 +191,7 @@ describe('RouteLayer', () => {
       );
     });
 
-    expect(styleBus[3].getImage()).toEqual(
+    expect(styleBus[2].getImage()).toEqual(
       new Icon({
         src: finishFlag,
         anchor: [4.5, 3.5],


### PR DESCRIPTION
# How to

The route circle markers are currently displayed at the start and end of each route sequence.
These now render only at the start and end coordinates of each route. Unit tests were adjusted accordingly.

Test: https://deploy-preview-743--trafimage-maps.netlify.app

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] IE11 tested.
- [x] The title means something for a human being.
- [x] The title contains [WIP] if it's necessary.
- [x] Labels applied. if it's a release? a hotfix?
- [x] Tests added.
