### PR TITLE
Load mbMap with filtered style layers

### DIFF
--- a/src/config/topics.js
+++ b/src/config/topics.js
@@ -100,7 +100,13 @@ export const casaNetzkartePersonenverkehr = new TrafimageMapboxLayer({
   visible: true,
   isBaseLayer: true,
   style: 'base_bright_v2',
-  filters: [{ type: /symbol|circle/i }],
+  filters: [
+    {
+      field: 'type',
+      value: /symbol|circle/,
+      include: false,
+    },
+  ],
   properties: {
     radioGroup: 'baseLayer',
   },
@@ -114,7 +120,13 @@ const casaNetzkarteShowcasesLight = new TrafimageMapboxLayer({
   preserveDrawingBuffer: true,
   zIndex: -1, // Add zIndex as the MapboxLayer would block tiled layers (buslines)
   style: 'casa_v1',
-  filters: [{ type: /symbol|circle/i }],
+  filters: [
+    {
+      field: 'type',
+      value: /symbol|circle/,
+      include: false,
+    },
+  ],
   properties: {
     radioGroup: 'baseLayer',
   },
@@ -124,21 +136,18 @@ export const netzkarteLayerLabels = new TrafimageMapboxLayer({
   name: 'ch.sbb.netzkarte-labels',
   visible: true,
   style: 'base_bright_v2',
+  filters: [
+    {
+      field: 'type',
+      value: /symbol|circle/i,
+      include: true,
+    },
+  ],
   properties: {
     hideInLegend: true,
   },
 });
 
-// Display only symbols and circle styles and set layer zIndex
-netzkarteLayerLabels.on('load', () => {
-  const styles = [...netzkarteLayerLabels.mbMap.getStyle().layers];
-  for (let i = 0; i < styles.length; i += 1) {
-    const style = styles[i];
-    if (!/symbol|circle/i.test(style.type)) {
-      netzkarteLayerLabels.mbMap.removeLayer(style.id);
-    }
-  }
-});
 netzkarteLayerLabels.olLayer.setZIndex(2);
 
 export const casa = {

--- a/src/config/topics.js
+++ b/src/config/topics.js
@@ -100,6 +100,7 @@ export const casaNetzkartePersonenverkehr = new TrafimageMapboxLayer({
   visible: true,
   isBaseLayer: true,
   style: 'base_bright_v2',
+  filters: [{ type: /symbol|circle/i }],
   properties: {
     radioGroup: 'baseLayer',
   },
@@ -113,22 +114,10 @@ const casaNetzkarteShowcasesLight = new TrafimageMapboxLayer({
   preserveDrawingBuffer: true,
   zIndex: -1, // Add zIndex as the MapboxLayer would block tiled layers (buslines)
   style: 'casa_v1',
+  filters: [{ type: /symbol|circle/i }],
   properties: {
     radioGroup: 'baseLayer',
   },
-});
-
-// Remove all symbols and circle styles from casa layers
-[casaNetzkartePersonenverkehr, casaNetzkarteShowcasesLight].forEach((layer) => {
-  layer.on('load', () => {
-    const styles = [...layer.mbMap.getStyle().layers];
-    for (let i = 0; i < styles.length; i += 1) {
-      const style = styles[i];
-      if (/symbol|circle/i.test(style.type)) {
-        layer.mbMap.removeLayer(style.id);
-      }
-    }
-  });
 });
 
 export const netzkarteLayerLabels = new TrafimageMapboxLayer({

--- a/src/examples/Casa/README.md
+++ b/src/examples/Casa/README.md
@@ -131,15 +131,15 @@ routeLayer
     {
       isClickable: true,
       isSelected: false,
-      popupTitle: 'Route St. Gallen >> Zürich',
+      popupTitle: 'Route Biel/Bienne >> Freiburg/Fribourg',
       popupContent: {
-        Von: 'St. Gallen',
-        Nach: 'Zürich HB',
+        Von: 'Bern',
+        Nach: 'Freiburg/Fribourg',
       },
       sequences: [
         {
-          uicFrom: 8506306,
-          uicTo: 8503000,
+          uicFrom: 8507000,
+          uicTo: 8504100,
           mot: 'rail',
         },
       ],
@@ -149,20 +149,20 @@ routeLayer
       isSelected: true,
       sequences: [
         {
-          uicFrom: 8503000,
+          uicFrom: 8500218,
           uicTo: 8507000,
           mot: 'rail',
         },
         {
           uicFrom: 8507000,
-          uicTo: 8576579,
+          uicTo: 8588105,
           mot: 'bus',
         },
       ],
     },
   ])
   .then(f => {
-    routeLayer.zoomToRoute();
+    routeLayer.zoomToRoute({duration: 1000});
   });
 
 routeLayer.onClick(f => {

--- a/src/layers/MapboxStyleLayer/MapboxStyleLayer.test.js
+++ b/src/layers/MapboxStyleLayer/MapboxStyleLayer.test.js
@@ -1,7 +1,7 @@
 import 'jest-canvas-mock';
 import Map from 'ol/Map';
 import View from 'ol/View';
-import mapboxgl from 'mapbox-gl';
+// import mapboxgl from 'mapbox-gl';
 import TrafimageMapboxLayer from '../TrafimageMapboxLayer';
 import MapboxStyleLayer from '.';
 
@@ -40,11 +40,11 @@ describe('MapboxStyleLayer', () => {
     expect(layer.mbMap).toBe();
   });
 
-  test('should initalized mapbox map.', () => {
-    source.init(map);
-    layer.init(map);
-    expect(layer.mapboxLayer.mbMap).toBeInstanceOf(mapboxgl.Map);
-  });
+  // test('should initalized mapbox map.', () => {
+  //   source.init(map);
+  //   layer.init(map);
+  //   expect(layer.mapboxLayer.mbMap).toBeInstanceOf(mapboxgl.Map);
+  // });
 
   test('should called terminate on initalization.', () => {
     const spy = jest.spyOn(layer, 'terminate');

--- a/src/layers/MapboxStyleLayer/MapboxStyleLayer.test.js
+++ b/src/layers/MapboxStyleLayer/MapboxStyleLayer.test.js
@@ -1,7 +1,7 @@
 import 'jest-canvas-mock';
 import Map from 'ol/Map';
 import View from 'ol/View';
-// import mapboxgl from 'mapbox-gl';
+import mapboxgl from 'mapbox-gl';
 import TrafimageMapboxLayer from '../TrafimageMapboxLayer';
 import MapboxStyleLayer from '.';
 
@@ -40,11 +40,12 @@ describe('MapboxStyleLayer', () => {
     expect(layer.mbMap).toBe();
   });
 
-  // test('should initalized mapbox map.', () => {
-  //   source.init(map);
-  //   layer.init(map);
-  //   expect(layer.mapboxLayer.mbMap).toBeInstanceOf(mapboxgl.Map);
-  // });
+  test.only('should initalized mapbox map.', async () => {
+    source.init(map);
+    await source.loadMbMap();
+    layer.init(map);
+    expect(layer.mapboxLayer.mbMap).toBeInstanceOf(mapboxgl.Map);
+  });
 
   test('should called terminate on initalization.', () => {
     const spy = jest.spyOn(layer, 'terminate');

--- a/src/layers/MapboxStyleLayer/MapboxStyleLayer.test.js
+++ b/src/layers/MapboxStyleLayer/MapboxStyleLayer.test.js
@@ -13,6 +13,10 @@ const styleLayer = {
   id: 'layer',
 };
 
+const mockFetchPromise = Promise.resolve({
+  json: () => Promise.resolve({}),
+});
+
 describe('MapboxStyleLayer', () => {
   beforeEach(() => {
     source = new TrafimageMapboxLayer({
@@ -40,7 +44,8 @@ describe('MapboxStyleLayer', () => {
     expect(layer.mbMap).toBe();
   });
 
-  test.only('should initalized mapbox map.', async () => {
+  test('should initalized mapbox map.', async () => {
+    jest.spyOn(global, 'fetch').mockImplementation(() => mockFetchPromise);
     source.init(map);
     await source.loadMbMap();
     layer.init(map);

--- a/src/layers/RouteLayer/RouteLayer.js
+++ b/src/layers/RouteLayer/RouteLayer.js
@@ -294,7 +294,9 @@ class RouteLayer extends CasaLayer {
    */
   zoomToRoute(options) {
     const fitOptions = { padding: [20, 20, 20, 20], ...options };
-    this.map.getView().fit(this.olLayer.getSource().getExtent(), fitOptions);
+    if (this.map) {
+      this.map.getView().fit(this.olLayer.getSource().getExtent(), fitOptions);
+    }
   }
 
   /**

--- a/src/layers/TrafimageMapboxLayer/TrafimageMapboxLayer.js
+++ b/src/layers/TrafimageMapboxLayer/TrafimageMapboxLayer.js
@@ -108,10 +108,15 @@ class TrafimageMapboxLayer extends MapboxLayer {
     }
 
     /* Get the MapBox style */
-    const mapboxStyle = await getMapboxStyle(this.styleUrl);
+    let mapboxStyle = null;
+    try {
+      mapboxStyle = await getMapboxStyle(this.styleUrl);
+    } catch {
+      console.error('Failed to fetch Mapbox style');
+    }
 
     /* Apply filters, remove style layers */
-    if (this.options.filters) {
+    if (mapboxStyle && this.options.filters) {
       const layers = [];
       this.options.filters.forEach((filter) => {
         const styleLayers = mapboxStyle.layers;
@@ -139,7 +144,7 @@ class TrafimageMapboxLayer extends MapboxLayer {
        * @type {mapboxgl.Map}
        */
       this.mbMap = new mapboxgl.Map({
-        style: mapboxStyle,
+        style: mapboxStyle || this.styleUrl,
         attributionControl: false,
         boxZoom: false,
         center: toLonLat([x, y]),
@@ -152,7 +157,7 @@ class TrafimageMapboxLayer extends MapboxLayer {
       });
     } catch (err) {
       // eslint-disable-next-line no-console
-      console.warn('Failed creating mapbox map: ', err);
+      console.warn('Failed creating Mapbox map: ', err);
     }
 
     // Options the last render run did happen. If something changes

--- a/src/layers/TrafimageMapboxLayer/TrafimageMapboxLayer.js
+++ b/src/layers/TrafimageMapboxLayer/TrafimageMapboxLayer.js
@@ -111,31 +111,30 @@ class TrafimageMapboxLayer extends MapboxLayer {
     let mapboxStyle = null;
     try {
       mapboxStyle = await getMapboxStyle(this.styleUrl);
+      /* Apply filters, remove style layers */
+      if (mapboxStyle && this.options.filters) {
+        const layers = [];
+        this.options.filters.forEach((filter) => {
+          const styleLayers = mapboxStyle.layers;
+          for (let i = 0; i < styleLayers.length; i += 1) {
+            const style = styleLayers[i];
+            /* filter.included boolean determines if the identified
+             * styleLayers or all others should be removed
+             */
+            const condition = filter.include
+              ? filter.value.test(style[filter.field])
+              : !filter.value.test(style[filter.field]);
+
+            if (condition) {
+              // mapboxStyle.layers.splice(i, 1);
+              layers.push(mapboxStyle.layers[i]);
+            }
+          }
+        });
+        mapboxStyle.layers = layers;
+      }
     } catch {
       console.error('Failed to fetch Mapbox style');
-    }
-
-    /* Apply filters, remove style layers */
-    if (mapboxStyle && this.options.filters) {
-      const layers = [];
-      this.options.filters.forEach((filter) => {
-        const styleLayers = mapboxStyle.layers;
-        for (let i = 0; i < styleLayers.length; i += 1) {
-          const style = styleLayers[i];
-          /* filter.included boolean determines if the identified
-           * styleLayers or all others should be removed
-           */
-          const condition = filter.include
-            ? filter.value.test(style[filter.field])
-            : !filter.value.test(style[filter.field]);
-
-          if (condition) {
-            // mapboxStyle.layers.splice(i, 1);
-            layers.push(mapboxStyle.layers[i]);
-          }
-        }
-      });
-      mapboxStyle.layers = layers;
     }
 
     try {

--- a/src/layers/TrafimageMapboxLayer/TrafimageMapboxLayer.js
+++ b/src/layers/TrafimageMapboxLayer/TrafimageMapboxLayer.js
@@ -108,21 +108,26 @@ class TrafimageMapboxLayer extends MapboxLayer {
     }
 
     /* Get the MapBox style */
-    const data = await getMapboxStyle(this.styleUrl);
+    const mapboxStyle = await getMapboxStyle(this.styleUrl);
 
     /* Apply filters, remove style layers */
     if (this.options.filters) {
+      const layers = [];
       this.options.filters.forEach((filter) => {
-        const styleLayers = data.layers;
+        const styleLayers = mapboxStyle.layers;
         for (let i = 0; i < styleLayers.length; i += 1) {
           const style = styleLayers[i];
-          if (
-            filter[Object.keys(filter)[0]].test(style[Object.keys(filter)[0]])
-          ) {
-            data.layers.splice(i, 1);
+          const condition = filter.include
+            ? filter.value.test(style[filter.field])
+            : !filter.value.test(style[filter.field]);
+
+          if (condition) {
+            // data.layers.splice(i, 1);
+            layers.push(mapboxStyle.layers[i]);
           }
         }
       });
+      mapboxStyle.layers = layers;
     }
 
     try {
@@ -131,7 +136,7 @@ class TrafimageMapboxLayer extends MapboxLayer {
        * @type {mapboxgl.Map}
        */
       this.mbMap = new mapboxgl.Map({
-        style: data,
+        style: mapboxStyle,
         attributionControl: false,
         boxZoom: false,
         center: toLonLat([x, y]),

--- a/src/layers/TrafimageMapboxLayer/TrafimageMapboxLayer.js
+++ b/src/layers/TrafimageMapboxLayer/TrafimageMapboxLayer.js
@@ -117,12 +117,15 @@ class TrafimageMapboxLayer extends MapboxLayer {
         const styleLayers = mapboxStyle.layers;
         for (let i = 0; i < styleLayers.length; i += 1) {
           const style = styleLayers[i];
+          /* filter.included boolean determines if the identified
+           * styleLayers or all others should be removed
+           */
           const condition = filter.include
             ? filter.value.test(style[filter.field])
             : !filter.value.test(style[filter.field]);
 
           if (condition) {
-            // data.layers.splice(i, 1);
+            // mapboxStyle.layers.splice(i, 1);
             layers.push(mapboxStyle.layers[i]);
           }
         }
@@ -181,6 +184,7 @@ class TrafimageMapboxLayer extends MapboxLayer {
         type: 'load',
         target: this,
       });
+      this.olLayer.changed();
     });
 
     const mapboxCanvas = this.mbMap.getCanvas();

--- a/src/layers/TrafimageMapboxLayer/TrafimageMapboxLayer.js
+++ b/src/layers/TrafimageMapboxLayer/TrafimageMapboxLayer.js
@@ -1,4 +1,29 @@
 import { MapboxLayer } from 'mobility-toolbox-js/ol';
+import { toLonLat } from 'ol/proj';
+import mapboxgl from 'mapbox-gl';
+
+const getCopyrightFromSources = (mbMap) => {
+  let copyrights = [];
+  const regex = /<[^>]*>[^>]*<\/[^>]*>/g;
+  // Trick from Mapbox AttributionControl to know if the source is used.
+  const { sourceCaches } = mbMap.style;
+  Object.entries(sourceCaches).forEach(([, sourceCache]) => {
+    if (sourceCache.used) {
+      copyrights = copyrights.concat(
+        regex.exec(sourceCache.getSource().attribution),
+      );
+    }
+  });
+  return Array.from(
+    new Set(copyrights.filter((copyright) => !!copyright)),
+  ).join(', ');
+};
+
+const getMapboxStyle = async (url) => {
+  const response = await fetch(url);
+  const data = await response.json();
+  return data;
+};
 
 class TrafimageMapboxLayer extends MapboxLayer {
   init(map) {
@@ -68,6 +93,101 @@ class TrafimageMapboxLayer extends MapboxLayer {
           });
         });
       });
+  }
+
+  /**
+   * Create the mapbox map.
+   */
+  async loadMbMap() {
+    // If the map hasn't been resized, the center could be [NaN,NaN].
+    // We set default good value for the mapbox map, to avoid the app crashes.
+    let [x, y] = this.map.getView().getCenter();
+    if (!x || !y) {
+      x = 0;
+      y = 0;
+    }
+
+    /* Get the MapBox style */
+    const data = await getMapboxStyle(this.styleUrl);
+
+    /* Apply filters, remove style layers */
+    if (this.options.filters) {
+      this.options.filters.forEach((filter) => {
+        const styleLayers = data.layers;
+        for (let i = 0; i < styleLayers.length; i += 1) {
+          const style = styleLayers[i];
+          if (
+            filter[Object.keys(filter)[0]].test(style[Object.keys(filter)[0]])
+          ) {
+            data.layers.splice(i, 1);
+          }
+        }
+      });
+    }
+
+    try {
+      /**
+       * A mapbox map
+       * @type {mapboxgl.Map}
+       */
+      this.mbMap = new mapboxgl.Map({
+        style: data,
+        attributionControl: false,
+        boxZoom: false,
+        center: toLonLat([x, y]),
+        container: this.map.getTargetElement(),
+        interactive: false,
+        fadeDuration:
+          'fadeDuration' in this.options ? this.options.fadeDuration : 300,
+        // Needs to be true to able to export the canvas, but could lead to performance issue on mobile.
+        preserveDrawingBuffer: this.options.preserveDrawingBuffer || false,
+      });
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn('Failed creating mapbox map: ', err);
+    }
+
+    // Options the last render run did happen. If something changes
+    // we have to render again
+    /** @ignore */
+    this.renderState = {
+      center: [x, y],
+      zoom: null,
+      rotation: null,
+      visible: null,
+      opacity: null,
+      size: [0, 0],
+    };
+
+    this.mbMap.once('load', () => {
+      /**
+       * Is the map loaded.
+       * @type {boolean}
+       */
+      this.loaded = true;
+      if (!this.copyright) {
+        /**
+         * Copyright statement.
+         * @type {string}
+         */
+        this.copyright = getCopyrightFromSources(this.mbMap);
+      }
+      this.dispatchEvent({
+        type: 'load',
+        target: this,
+      });
+    });
+
+    const mapboxCanvas = this.mbMap.getCanvas();
+    if (mapboxCanvas) {
+      if (this.options.tabIndex) {
+        mapboxCanvas.setAttribute('tabindex', this.options.tabIndex);
+      } else {
+        // With a tabIndex='-1' the mouse events works but the map is not focused when we click on it
+        // so we remove completely the tabIndex attribute.
+        mapboxCanvas.removeAttribute('tabindex');
+      }
+    }
   }
 
   getFeatures({ source, sourceLayer, filter } = {}) {


### PR DESCRIPTION
# How to

Updates: 
* Added a filter option to TrafImageMapboxMap
* loadMbMap() overwritten in TrafimageMapboxMap, added filter handling to remove layers from the style object.
* Updated tests

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] IE11 tested.
- [ ] The title means something for a human being.
- [ ] The title contains [WIP] if it's necessary.
- [ ] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
