### PR TITLE
Fix logged in user name when too long, with ellipsis

### DIFF
--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -21,7 +21,7 @@
     position: absolute;
     right: 10px;
     top: 0;
-    left: calc(100% - 465px);
+    left: calc(100% - 475px);
 
     .wkp-header-sbb-logo-wrapper {
       position: absolute;
@@ -32,6 +32,14 @@
       .wkp-header-sbb-logo {
         height: 100%;
         width: 100%;
+      }
+    }
+
+    .wkp-login {
+      .wkp-login-text {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 90px;
       }
     }
   }

--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -32,6 +32,7 @@ const Login = ({ appBaseUrl }) => {
       onClick={openLoginPage}
       onKeyPress={(evt) => evt.which === 13 && openLoginPage()}
       tabIndex={0}
+      title={permissionsInfos && permissionsInfos.user}
     >
       <SBBUser focusable={false} className="wkp-login-icon" />
       <span className="wkp-login-text">{login}</span>

--- a/src/components/Login/__snapshots__/Login.test.js.snap
+++ b/src/components/Login/__snapshots__/Login.test.js.snap
@@ -29,6 +29,7 @@ exports[`Login matches snapshot displaying user name 1`] = `
   onKeyPress={[Function]}
   role="button"
   tabIndex={0}
+  title="bar"
 >
   <svg
     className="wkp-login-icon"


### PR DESCRIPTION
# How to

<!--  Please provide a test link and quick description how to see the change -->
To test the length we can simply replace the button text with a long dummy name: test.username_test.de#EXT#

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [ ] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] IE11 tested.
- [x] The title means something for a human being.
- [x] The title contains [WIP] if it's necessary.
- [x] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
