### PR TITLE
Add configurable url to RouteLayer and ZoneLayer

### DIFF
--- a/src/layers/RouteLayer/RouteLayer.js
+++ b/src/layers/RouteLayer/RouteLayer.js
@@ -26,6 +26,7 @@ import finishFlag from '../../img/finish_flag.png';
  * @extends CasaLayer
  * @param {Object} [options] Layer options.
  *   Default is `{ rail: '#e3000b', bus: '#ffed00', ship: '#0074be' }`.
+ * @param {string} [options.url = https://api.geops.io/routing/v1] Url to fetch routes.
  */
 class RouteLayer extends CasaLayer {
   static getCircleStyle = (coords) =>
@@ -61,7 +62,7 @@ class RouteLayer extends CasaLayer {
 
     this.featuresLayer = this.olLayer;
 
-    this.url = 'https://api.geops.io/routing/v1/';
+    this.url = options.url || 'https://api.geops.io/routing/v1';
 
     this.selectedRouteIds = [];
 
@@ -142,7 +143,7 @@ class RouteLayer extends CasaLayer {
       mot,
     };
 
-    const url = `${this.url}?${qs.stringify(urlParams)}`;
+    const url = `${this.url}/?${qs.stringify(urlParams)}`;
     const format = new GeoJSON({
       dataProjection: 'EPSG:4326',
       featureProjection: this.projection,

--- a/src/layers/ZoneLayer/ZoneLayer.js
+++ b/src/layers/ZoneLayer/ZoneLayer.js
@@ -19,6 +19,7 @@ import CasaLayer from '../CasaLayer';
  * @class ZoneLayer
  * @extends CasaLayer
  * @param {Object} options Layer options.
+ * @param {string} [options.url = https://api.geops.io/casa-fare-network/v1] Url to fetch zones.
  * @param {string} [options.validFrom] Zone validity start. Format: yyyy-mm-dd.
  * @param {string} [options.validTo] Zone validity end . Format: yyyy-mm-dd.
  * @param {number} [options.simplify = 100] Simplification measurement for
@@ -78,7 +79,7 @@ class ZoneLayer extends CasaLayer {
     this.simplify =
       typeof options.simplify === 'undefined' ? 100 : options.simplify;
 
-    this.url = 'https://api.geops.io/casa-fare-network/v1';
+    this.url = options.url || 'https://api.geops.io/casa-fare-network/v1';
 
     this.labelOptimizeMinRes = options.labelOptimizationMinResolution || 100;
 


### PR DESCRIPTION
See ROKAS-68

# How to

<!--  Please provide a test link and quick description how to see the change -->
The application should behave the same. The RouteLayer and ZoneLayer should still use the default urls. However, it's possible to change these urls.

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] Everything in ticket description has been fixed. (Together with https://github.com/geops/trafimage-maps/pull/795)
- [x] The author of the MR has made its own review before assigning the reviewer.
- [ ] IE11 tested.
- [x] The title means something for a human being.
- [x] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
