### PR TITLE
Added profile=sbb to CASA routing requests

### DIFF
--- a/src/layers/RouteLayer/RouteLayer.js
+++ b/src/layers/RouteLayer/RouteLayer.js
@@ -138,6 +138,7 @@ class RouteLayer extends CasaLayer {
 
     const via = viaPoints.map((v) => `!${v}`);
     const urlParams = {
+      profile: 'sbb',
       key: this.apiKey || '',
       via: via.join('|'),
       mot,


### PR DESCRIPTION
# How to

Updates: Added the **profile** parameter to CASA routing API requests, fixes erratic routing

Test: 
- Testing can be done in the CASA example of the [style guide review app](https://deploy-preview-801--trafimage-maps.netlify.app/?baselayers=ch.sbb.netzkarte,ch.sbb.netzkarte.luftbild.group,ch.sbb.netzkarte.landeskarte,ch.sbb.netzkarte.landeskarte.grau&lang=de&layers=&x=925472&y=5920000&z=7#/Examples/Casa%20Map)
- Requests to https://api.geops.io/routing/v1/ should include a profile=sbb parameter
- Routes can be changed by changing route UICs in the CASA example sandbox code (note that the station needs to include the MOT specified in the route)


# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] IE11 tested.
- [x] The title means something for a human being.
- [x] The title contains [WIP] if it's necessary.
- [ ] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
