### PR TITLE
Passenger frequencies - Circle area instead of circle radius

### DIFF
--- a/src/config/layers.js
+++ b/src/config/layers.js
@@ -205,11 +205,11 @@ export const passagierfrequenzen = new MapboxStyleLayer({
       'circle-radius': [
         'interpolate',
         ['linear'],
-        ['get', 'dwv'],
-        400,
-        8,
-        500000,
-        70,
+        ['sqrt', ['get', 'dwv']], // We use the passenger square root so the radius is proportional to the circle are
+        0, // Radius at 0 passengers should be 0
+        0,
+        Math.sqrt(500000), // Radius at 500000 passengers should be Math.sqrt(500000)/10 (divide by 10 for better proportions)
+        Math.sqrt(500000) / 10,
       ],
       'circle-color': 'rgb(255,220,0)',
       'circle-stroke-width': 2,


### PR DESCRIPTION
# How to

**Task**: Passenger frequency numbers should be proportional to the circle area instead of the circle radius

**Solution**: Mapbox circle paint properties have no circle-area property, only circle-radius. Hence the square root of the passenger frequency is used to calculate the radius, instead of the absolute values, producing the desired result.

**Test**: Compare passenger frequencies layer in the [review app](url) the prod version and see the difference

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] IE11 tested.
- [x] The title means something for a human being.
- [x] The title contains [WIP] if it's necessary.
- [ ] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
