### PR TITLE
Encode search queries

### DIFF
--- a/src/searches/Betriebspunkte/Betriebspunkte.js
+++ b/src/searches/Betriebspunkte/Betriebspunkte.js
@@ -11,7 +11,9 @@ class Betriebspunkte extends Search {
 
   // eslint-disable-next-line class-methods-use-this
   search(value) {
-    return fetch(`https://maps.trafimage.ch/search/bps?name=${value}`)
+    return fetch(
+      `https://maps.trafimage.ch/search/bps?name=${encodeURIComponent(value)}`,
+    )
       .then((data) => data.json())
       .then((featureCollection) => featureCollection.features)
       .catch(() => {

--- a/src/searches/HandicapStopFinder/HandicapStopFinder.js
+++ b/src/searches/HandicapStopFinder/HandicapStopFinder.js
@@ -16,7 +16,9 @@ class HandicapStopFinder extends Search {
   }
 
   search(value) {
-    return fetch(`${endpoint}?&q=${value}&key=${this.apiKey}`)
+    return fetch(
+      `${endpoint}?&q=${encodeURIComponent(value)}&key=${this.apiKey}`,
+    )
       .then((data) => data.json())
       .then((featureCollection) => featureCollection.features)
       .catch(() => {

--- a/src/searches/Lines/Lines.js
+++ b/src/searches/Lines/Lines.js
@@ -68,7 +68,7 @@ class Lines extends Search {
 
   // eslint-disable-next-line class-methods-use-this
   search(value) {
-    let params = `line=${value}`;
+    let params = `line=${encodeURIComponent(value)}`;
     if (lineKilometerRegExp.test(value)) {
       const [, line, km] = value.match(lineKilometerRegExp);
       params = `line=${line}&km=${km}`;

--- a/src/searches/Locations/Locations.js
+++ b/src/searches/Locations/Locations.js
@@ -6,7 +6,9 @@ class Locations extends Search {
   // eslint-disable-next-line class-methods-use-this
   search(value) {
     return fetch(
-      `https://maps.trafimage.ch/api3-geo-admin/SearchServer?type=locations&searchText=${value}`,
+      `https://maps.trafimage.ch/api3-geo-admin/SearchServer?type=locations&searchText=${encodeURIComponent(
+        value,
+      )}`,
     )
       .then((data) => data.json())
       .then((response) =>

--- a/src/searches/Municipalities/Municipalities.js
+++ b/src/searches/Municipalities/Municipalities.js
@@ -12,7 +12,9 @@ class Municipalities extends Search {
   // eslint-disable-next-line class-methods-use-this
   search(value) {
     return fetch(
-      `https://maps.trafimage.ch/search/municipalities?query=${value}&utf8=%E2%9C%93`,
+      `https://maps.trafimage.ch/search/municipalities?query=${encodeURIComponent(
+        value,
+      )}&utf8=%E2%9C%93`,
     )
       .then((data) => data.json())
       .then((featureCollection) => featureCollection.features)

--- a/src/searches/StopFinder/StopFinder.js
+++ b/src/searches/StopFinder/StopFinder.js
@@ -16,7 +16,9 @@ class StopFinder extends Search {
   }
 
   search(value) {
-    return fetch(`${endpoint}?&q=${value}&key=${this.apiKey}`)
+    return fetch(
+      `${endpoint}?&q=${encodeURIComponent(value)}&key=${this.apiKey}`,
+    )
       .then((data) => data.json())
       .then((featureCollection) => featureCollection.features)
       .catch(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3843,9 +3843,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30000989, caniuse-lite@^1.0.30001035, caniuse-lite@^1.0.30001038, caniuse-lite@^1.0.30001039:
-  version "1.0.30001039"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001039.tgz#b3814a1c38ffeb23567f8323500c09526a577bbe"
-  integrity sha512-SezbWCTT34eyFoWHgx8UWso7YtvtM7oosmFoXbCkdC6qJzRfBTeTgE9REtKtiuKXuMwWTZEvdnFNGAyVMorv8Q==
+  version "1.0.30001137"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001137.tgz"
+  integrity sha512-54xKQZTqZrKVHmVz0+UvdZR6kQc7pJDgfhsMYDG19ID1BWoNnDMFm5Q3uSBSU401pBvKYMsHAt9qhEDcxmk8aw==
 
 canvas@2.6.1:
   version "2.6.1"
@@ -10616,15 +10616,15 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.15, "lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.1.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0, lodash@~4.17.12:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
-
 lodash@4.17.19, lodash@^4.17.11:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
+
+"lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.1.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0, lodash@~4.17.12:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
 lodash@^4.17.19:
   version "4.17.20"


### PR DESCRIPTION
...for:

- StopFinder
- Betriebspunkte
- Lines
- Locations
- Municipalities

...which fixes the search in IE with umlauts.

See TRAFMBB-21

Same as https://github.com/geops/react-transit/pull/285 from https://jira.geops.ch/browse/MAPSET-59

# How to

<!--  Please provide a test link and quick description how to see the change -->

- Open review app in IE
- Search for "Zür"
=> The Stationen "Zürich HB" and "Zürich Oerlikon" should appear.

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [ ] IE11 tested.
- [x] The title means something for a human being.
- [ ] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
