### PR TITLE
Fix menu which was overlapped by the search at large (.tm-w-l) screens

### DIFF
--- a/src/components/TrafimageMaps/TrafimageMaps.scss
+++ b/src/components/TrafimageMaps/TrafimageMaps.scss
@@ -199,7 +199,6 @@
   &.tm-w-xs {
     .wkp-search {
       min-width: unset;
-      left: 55px;
     }
 
     .wkp-search-toggle-container--open {
@@ -313,6 +312,7 @@
       top: 3px;
       right: 9px;
       max-width: 100%;
+      left: 55px;
 
       .wkp-search-toggle-button {
         svg {


### PR DESCRIPTION
Bug without ticket

The element .wkp-search must not overlap the menu.

# How to

<!--  Please provide a test link and quick description how to see the change -->

- Open the application at a screen width of .tm-w-l
- Set the cursor into the search field
- Try to click on the arrow of the menu
=> The menu should open

The same should happen for all screen widths. 

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [ ] Everything in ticket description has been fixed. - There is no ticket
- [x] The author of the MR has made its own review before assigning the reviewer.
- [ ] IE11 tested.
- [x] The title means something for a human being.
- [ ] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
