### PR TITLE
[TRAFKLEIN-475] Allow to still see trajectories on click when menu is…

### DIFF
--- a/src/components/MapControls/MapControls.scss
+++ b/src/components/MapControls/MapControls.scss
@@ -48,6 +48,7 @@
 
 .wkp-map-controls {
   position: absolute;
+  z-index: 1;
   right: 15px;
   top: 110px;
 

--- a/src/components/TopicElements/TopicElements.js
+++ b/src/components/TopicElements/TopicElements.js
@@ -35,6 +35,7 @@ const defaultElements = {
   baseLayerSwitcher: false,
   shareMenu: false,
   trackerMenu: false,
+  altTrackerMenu: false,
   featureMenu: false,
   search: false,
 };
@@ -109,6 +110,10 @@ function TopicElements({ history, appBaseUrl, staticFilesUrl }) {
   elements.telephoneInfos =
     !disabled || !disabled.split(',').find((el) => el === 'header');
 
+  // If menu disable, we should be able to see trajectories [TRAFKLEIN-475]
+  elements.altTrackerMenu =
+    disabled && disabled.split(',').find((el) => el === 'menu');
+
   // Define which component to display as child of TopicsMenu.
   const appTopicsMenuChildren = getComponents(
     { shareMenu: <ShareMenu appBaseUrl={appBaseUrl} /> },
@@ -144,6 +149,11 @@ function TopicElements({ history, appBaseUrl, staticFilesUrl }) {
       <Menu>
         <TopicsMenu>{appTopicsMenuChildren}</TopicsMenu>
         {appMenuChildren}
+      </Menu>
+    ),
+    altTrackerMenu: (
+      <Menu>
+        <TrackerMenu />
       </Menu>
     ),
     baseLayerSwitcher: (

--- a/src/components/TopicElements/TopicElements.js
+++ b/src/components/TopicElements/TopicElements.js
@@ -135,6 +135,7 @@ function TopicElements({ history, appBaseUrl, staticFilesUrl }) {
   const appComponents = {
     header: <Header appBaseUrl={appBaseUrl} />,
     search: <Search />,
+    mapControls: <MapControls showGeolocation={elements.geolocationButton} />,
     map: (
       <EventConsumer>
         {(dispatcher) => (
@@ -168,7 +169,6 @@ function TopicElements({ history, appBaseUrl, staticFilesUrl }) {
         t={t}
       />
     ),
-    mapControls: <MapControls showGeolocation={elements.geolocationButton} />,
     footer: <Footer />,
   };
 


### PR DESCRIPTION
Allow to still see trajectories on click when menu is disabled
Move map controls before the map in the tab order

# How to

<!--  Please provide a test link and quick description how to see the change -->

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [ ] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [ ] IE11 tested.
- [x] The title means something for a human being.
- [x] The title contains [WIP] if it's necessary.
- [x] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
