### PR TITLE
Infos on empty handicap popup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trafimage-maps",
-  "version": "1.3.0-beta.14",
+  "version": "1.3.0-beta.15",
   "private": true,
   "main": "build/bundle.js",
   "proxy": "http://127.0.0.1:8000",

--- a/src/popups/HandicapPopup/HandicapPopup.js
+++ b/src/popups/HandicapPopup/HandicapPopup.js
@@ -180,9 +180,12 @@ function HandicapPopup({ feature }) {
     );
   }
 
-  return (
-    <div className="wkp-handicap-popup">
-      <div className="wkp-handicap-popup-body">
+  const renderBody = () => {
+    if (properties.noInfo) {
+      return <span tabIndex={0}>{t('Keine Information vorhanden.')}</span>;
+    }
+    return (
+      <>
         <div
           className="wkp-handicap-popup-title"
           tabIndex={0}
@@ -210,7 +213,13 @@ function HandicapPopup({ feature }) {
           );
         })}
         {renderBottom(properties)}
-      </div>
+      </>
+    );
+  };
+
+  return (
+    <div className="wkp-handicap-popup">
+      <div className="wkp-handicap-popup-body">{renderBody()}</div>
     </div>
   );
 }

--- a/src/searches/HandicapStopFinder/HandicapStopFinder.js
+++ b/src/searches/HandicapStopFinder/HandicapStopFinder.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import { Feature } from 'ol';
+import { Point } from 'ol/geom';
 import { fromLonLat } from 'ol/proj';
 import MapboxStyleLayer from '../../layers/MapboxStyleLayer';
 import Search from '../Search';
@@ -87,10 +89,23 @@ class HandicapStopFinder extends Search {
       )
       .filter((i) => i);
 
-    Promise.all(infos).then((featureInfos) => {
-      dispatchSetFeatureInfo(
-        featureInfos.filter(({ features }) => features.length),
-      );
+    Promise.all(infos).then((featInfos) => {
+      let featureInfos = featInfos.filter(({ features }) => features.length);
+      if (!featureInfos.length) {
+        const errorInfo = featInfos.find(
+          (l) => l.coordinate && l.layer.get('popupComponent'),
+        );
+        errorInfo.features = [
+          // Create empty feature to open popup with no infos - TRAFHAND-104.
+          new Feature({
+            geometry: new Point(errorInfo.coordinate),
+            stationsbezeichnung: this.popupItem.properties.name,
+            noInfo: true,
+          }),
+        ];
+        featureInfos = [errorInfo];
+      }
+      dispatchSetFeatureInfo(featureInfos);
     });
   }
 }

--- a/src/searches/HandicapStopFinder/HandicapStopFinder.js
+++ b/src/searches/HandicapStopFinder/HandicapStopFinder.js
@@ -44,14 +44,18 @@ class HandicapStopFinder extends Search {
 
     if (layer) {
       const { mbMap } = layer;
-      mbMap.once('idle', () => {
-        if (mbMap.isSourceLoaded('ch.sbb.handicap')) {
-          this.onDataEvent();
-        } else {
-          // We can't rely on sourcedata because isSourceLoaded returns false.
-          mbMap.on('idle', this.onDataEvent);
-        }
-      });
+      if (mbMap.loaded() && mbMap.isStyleLoaded()) {
+        this.onDataEvent();
+      } else {
+        mbMap.once('idle', () => {
+          if (mbMap.isSourceLoaded('ch.sbb.handicap')) {
+            this.onDataEvent();
+          } else {
+            // We can't rely on sourcedata because isSourceLoaded returns false.
+            mbMap.on('idle', this.onDataEvent);
+          }
+        });
+      }
     }
   }
 

--- a/src/searches/StopFinder/StopFinder.js
+++ b/src/searches/StopFinder/StopFinder.js
@@ -42,14 +42,18 @@ class StopFinder extends Search {
 
     if (layer) {
       const { mbMap } = layer;
-      mbMap.once('idle', () => {
-        if (mbMap.isSourceLoaded('stations')) {
-          this.onDataEvent();
-        } else {
-          // We can't rely on sourcedata because isSourceLoaded returns false.
-          mbMap.on('idle', this.onDataEvent);
-        }
-      });
+      if (mbMap.loaded() && mbMap.isStyleLoaded()) {
+        this.onDataEvent();
+      } else {
+        mbMap.once('idle', () => {
+          if (mbMap.isSourceLoaded('stations')) {
+            this.onDataEvent();
+          } else {
+            // We can't rely on sourcedata because isSourceLoaded returns false.
+            mbMap.on('idle', this.onDataEvent);
+          }
+        });
+      }
     }
   }
 


### PR DESCRIPTION
# How to

<!--  Please provide a test link and quick description how to see the change -->
In Handicap Topic, when selecting in the search bar station without infos, the popup indicates that there are no infos,
e.g search for 'jungfrauhoch', click on it.

Ticket:TRAFHAND-104

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [ ] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [ ] IE11 tested.
- [x] The title means something for a human being.
- [x] The title contains [WIP] if it's necessary.
- [x] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
