### PR TITLE
Allow handicap popup content to be read by screen reader

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "react-redux": "^7.2.0",
     "react-select": "^3.1.0",
     "react-shadow": "^17.6.0",
-    "react-spatial": "^1.0.5",
+    "react-spatial": "1.0.8",
     "react-styleguidist": "^11.0.4",
     "react-web-component": "^2.0.1",
     "redux": "^4.0.5",

--- a/src/components/FeatureInformation/FeatureInformation.js
+++ b/src/components/FeatureInformation/FeatureInformation.js
@@ -82,11 +82,16 @@ const FeatureInformation = ({ featureInfo, appBaseUrl, staticFilesUrl }) => {
     );
   }
   return (
-    <div className="wkp-feature-information">
+    <div
+      className="wkp-feature-information"
+      aria-labelledby="wkp-popup-label"
+      aria-describedby="wkp-popup-desc"
+      role="dialog"
+    >
       <React.Suspense fallback="...loading">
         {PopupComponent && !PopupComponent.hideHeader ? (
           <div className="wkp-feature-information-header">
-            <span>
+            <span id="wkp-popup-label">
               {PopupComponent && PopupComponent.renderTitle && feature
                 ? PopupComponent.renderTitle(feature, t)
                 : layer && layer.name && t(layer.name)}

--- a/src/components/FeatureInformation/__snapshots__/FeatureInformation.test.js.snap
+++ b/src/components/FeatureInformation/__snapshots__/FeatureInformation.test.js.snap
@@ -2,12 +2,17 @@
 
 exports[`FeatureInformaion should match snapshot. should display multiple features with pagination 1`] = `
 <div
+  aria-describedby="wkp-popup-desc"
+  aria-labelledby="wkp-popup-label"
   className="wkp-feature-information"
+  role="dialog"
 >
   <div
     className="wkp-feature-information-header"
   >
-    <span />
+    <span
+      id="wkp-popup-label"
+    />
     <div
       aria-label="Popup schliessen"
       className="wkp-close-bt"
@@ -131,7 +136,10 @@ exports[`FeatureInformaion should match snapshot. should display multiple featur
 
 exports[`FeatureInformaion should match snapshot. should not display header 1`] = `
 <div
+  aria-describedby="wkp-popup-desc"
+  aria-labelledby="wkp-popup-label"
   className="wkp-feature-information"
+  role="dialog"
 >
   <div
     className="wkp-feature-information-body"
@@ -156,12 +164,17 @@ exports[`FeatureInformaion should match snapshot. should not display header 1`] 
 
 exports[`FeatureInformaion should match snapshot. using the info's popupComponent 1`] = `
 <div
+  aria-describedby="wkp-popup-desc"
+  aria-labelledby="wkp-popup-label"
   className="wkp-feature-information"
+  role="dialog"
 >
   <div
     className="wkp-feature-information-header"
   >
-    <span />
+    <span
+      id="wkp-popup-label"
+    />
     <div
       aria-label="Popup schliessen"
       className="wkp-close-bt"
@@ -241,12 +254,17 @@ exports[`FeatureInformaion should match snapshot. using the info's popupComponen
 
 exports[`FeatureInformaion should match snapshot. using the layers's popupComponent 1`] = `
 <div
+  aria-describedby="wkp-popup-desc"
+  aria-labelledby="wkp-popup-label"
   className="wkp-feature-information"
+  role="dialog"
 >
   <div
     className="wkp-feature-information-header"
   >
-    <span />
+    <span
+      id="wkp-popup-label"
+    />
     <div
       aria-label="Popup schliessen"
       className="wkp-close-bt"

--- a/src/popups/HandicapPopup/HandicapPopup.js
+++ b/src/popups/HandicapPopup/HandicapPopup.js
@@ -14,15 +14,12 @@ function HandicapPopup({ feature }) {
   const properties = feature.getProperties();
   const { t } = useTranslation();
   const refBody = useRef();
-  const refBodyEmpty = useRef();
 
   useEffect(() => {
     // focus first element to trigger screenreader to read its content:
     // https://www.w3.org/TR/wai-aria-practices-1.1/examples/dialog-modal/dialog.html
     if (refBody && refBody.current) {
       refBody.current.focus();
-    } else if (refBodyEmpty && refBodyEmpty.current) {
-      refBodyEmpty.current.focus();
     }
   }, []);
 
@@ -187,7 +184,7 @@ function HandicapPopup({ feature }) {
   const renderBody = () => {
     if (properties.noInfo) {
       return (
-        <span tabIndex={-1} ref={refBodyEmpty}>
+        <span tabIndex={-1} ref={refBody}>
           {t('Keine Information vorhanden.')}
         </span>
       );

--- a/src/popups/HandicapPopup/HandicapPopup.js
+++ b/src/popups/HandicapPopup/HandicapPopup.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import Feature from 'ol/Feature';
@@ -13,6 +13,18 @@ function HandicapPopup({ feature }) {
   const language = useSelector((state) => state.app.language);
   const properties = feature.getProperties();
   const { t } = useTranslation();
+  const refBody = useRef();
+  const refBodyEmpty = useRef();
+
+  useEffect(() => {
+    // focus first element to trigger screenreader to read its content:
+    // https://www.w3.org/TR/wai-aria-practices-1.1/examples/dialog-modal/dialog.html
+    if (refBody && refBody.current) {
+      refBody.current.focus();
+    } else if (refBodyEmpty && refBodyEmpty.current) {
+      refBodyEmpty.current.focus();
+    }
+  }, []);
 
   // mapping of all boolean values properties and their exceptions
   const bfEquipmentExceptions = {
@@ -174,11 +186,17 @@ function HandicapPopup({ feature }) {
 
   const renderBody = () => {
     if (properties.noInfo) {
-      return <span>{t('Keine Information vorhanden.')}</span>;
+      return (
+        <span tabIndex={-1} ref={refBodyEmpty}>
+          {t('Keine Information vorhanden.')}
+        </span>
+      );
     }
     return (
       <>
-        <div className="wkp-handicap-popup-title">{titles.join(' / ')}</div>
+        <p className="wkp-handicap-popup-title" ref={refBody} tabIndex={-1}>
+          {titles.join(' / ')}
+        </p>
         {elementsList.map((field) => {
           if (!properties[field.propertyName] && !field.element) {
             return null;
@@ -204,7 +222,9 @@ function HandicapPopup({ feature }) {
 
   return (
     <div className="wkp-handicap-popup">
-      <div className="wkp-handicap-popup-body">{renderBody()}</div>
+      <div className="wkp-handicap-popup-body" id="wkp-popup-desc">
+        {renderBody()}
+      </div>
     </div>
   );
 }

--- a/src/popups/HandicapPopup/HandicapPopup.scss
+++ b/src/popups/HandicapPopup/HandicapPopup.scss
@@ -2,6 +2,11 @@
   min-width: 350px !important;
   max-width: 420px;
 
+  p {
+    margin-block-start: 0;
+    margin-block-end: 0;
+  }
+
   a {
     text-decoration: underline;
   }
@@ -25,7 +30,7 @@
   .wkp-handicap-popup-body {
     .wkp-handicap-popup-title {
       font-weight: bold;
-      padding-bottom: 10px;
+      margin-bottom: 10px;
     }
 
     .wkp-handicap-popup-element {

--- a/src/popups/HandicapPopup/HandicapPopupElement.js
+++ b/src/popups/HandicapPopup/HandicapPopupElement.js
@@ -136,7 +136,7 @@ function HandicapPopupElement({ properties, propertyName, label }) {
     content = (
       <>
         {propLabel ? (
-          <div className="wkp-handicap-popup-field-title">{t(propLabel)}</div>
+          <p className="wkp-handicap-popup-field-title">{t(propLabel)}</p>
         ) : null}
         <div className="wkp-handicap-popup-field-body">
           {values.map((v, idx) => {
@@ -145,7 +145,7 @@ function HandicapPopupElement({ properties, propertyName, label }) {
             }
             return (
               // eslint-disable-next-line react/no-array-index-key
-              <div key={idx}>{renderLinks(v)}</div>
+              <p key={idx}>{renderLinks(v)}</p>
             );
           })}
         </div>
@@ -155,11 +155,11 @@ function HandicapPopupElement({ properties, propertyName, label }) {
     content = (
       <>
         {propLabel ? (
-          <div className="wkp-handicap-popup-field-title">{t(propLabel)}</div>
+          <p className="wkp-handicap-popup-field-title">{t(propLabel)}</p>
         ) : null}
-        <div className="wkp-handicap-popup-field-body">
+        <p className="wkp-handicap-popup-field-body">
           {renderLinks(values[0])}
-        </div>
+        </p>
       </>
     );
   }

--- a/src/popups/HandicapPopup/HandicapPopupElement.test.js
+++ b/src/popups/HandicapPopup/HandicapPopupElement.test.js
@@ -82,7 +82,7 @@ describe('HandicapPopupElement', () => {
       );
       const children = wrapper.find('.wkp-handicap-popup-field-body').html();
       expect(children).toBe(
-        `<div class="wkp-handicap-popup-field-body">${string}</div>`,
+        `<p class="wkp-handicap-popup-field-body">${string}</p>`,
       );
     });
   });

--- a/src/popups/HandicapPopup/__snapshots__/HandicapPopupElement.test.js.snap
+++ b/src/popups/HandicapPopup/__snapshots__/HandicapPopupElement.test.js.snap
@@ -4,18 +4,18 @@ exports[`HandicapPopupElement matches 'Zusätzliche Informationen' snapshot. 1`]
 <div
   className="wkp-handicap-popup-element"
 >
-  <div
+  <p
     className="wkp-handicap-popup-field-title"
   >
     Zusätzliche Informationen
-  </div>
+  </p>
   <div
     className="wkp-handicap-popup-field-body"
   >
-    <div>
+    <p>
       Test line here
-    </div>
-    <div>
+    </p>
+    <p>
       <span>
               
       </span>
@@ -24,8 +24,8 @@ exports[`HandicapPopupElement matches 'Zusätzliche Informationen' snapshot. 1`]
       >
         +33 666 66 66
       </a>
-    </div>
-    <div>
+    </p>
+    <p>
       <span>
         <span>
                 
@@ -38,17 +38,17 @@ exports[`HandicapPopupElement matches 'Zusätzliche Informationen' snapshot. 1`]
           admin@email.it
         </a>
       </span>
-    </div>
-    <div>
+    </p>
+    <p>
             (text)
-    </div>
-    <div>
+    </p>
+    <p>
             LU-Tixi
-    </div>
-    <div>
+    </p>
+    <p>
             foo bar baz
-    </div>
-    <div>
+    </p>
+    <p>
       <span>
               
       </span>
@@ -66,14 +66,14 @@ exports[`HandicapPopupElement matches 'Zusätzliche Informationen' snapshot. 1`]
           Link.svg
         </svg>
       </a>
-    </div>
-    <div>
+    </p>
+    <p>
             Dritte Dienstleistung
-    </div>
-    <div>
+    </p>
+    <p>
             Freiburg
-    </div>
-    <div>
+    </p>
+    <p>
       <span>
               
       </span>
@@ -82,8 +82,8 @@ exports[`HandicapPopupElement matches 'Zusätzliche Informationen' snapshot. 1`]
       >
         +41 (0) 41 210 00 60
       </a>
-    </div>
-    <div>
+    </p>
+    <p>
       <span>
               
       </span>
@@ -101,7 +101,7 @@ exports[`HandicapPopupElement matches 'Zusätzliche Informationen' snapshot. 1`]
           Link.svg
         </svg>
       </a>
-    </div>
+    </p>
   </div>
 </div>
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1409,6 +1409,21 @@
     react-shadow "^17.1.3"
     rimraf "^3.0.0"
 
+"@geops/geops-ui@0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@geops/geops-ui/-/geops-ui-0.1.4.tgz#0c4d0a2a83e571b2b7536fda09d01ec6f5c62d7e"
+  integrity sha512-z/ldNH/VZ0pd8hsKeG4Xz74GHaD9CUsY4wqC/nQs0zHamHDmwr/zqfknIhJaL41W/lM0rKKkiMhVoL0lAjcVwQ==
+  dependencies:
+    "@material-ui/core" "^4.11.0"
+    "@material-ui/icons" "^4.9.1"
+    node-sass "^4.14.1"
+    prop-types "^15.7.2"
+    react "^16.13.1"
+    react-dom "^16.13.1"
+    react-router-dom "^5.2.0"
+    typeface-lato "^0.0.75"
+    uuid "^8.3.1"
+
 "@geops/geops-ui@^0.1.3":
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/@geops/geops-ui/-/geops-ui-0.1.3.tgz#0147e9345edb59798a3915221ebd3e5d9eaee0f0"
@@ -2132,6 +2147,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
   integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
 
+"@types/json-schema@^7.0.6":
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
+  integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
+
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -2752,6 +2772,11 @@ ajv-keywords@^3.1.0, ajv-keywords@^3.4.1:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.4.1.tgz#ef916e271c64ac12171fd8384eaae6b2345854da"
   integrity sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==
 
+ajv-keywords@^3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
+  integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
+
 ajv@^5.0.0, ajv@^5.2.3, ajv@^5.3.0:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
@@ -2766,6 +2791,16 @@ ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.0, ajv@^6.5.5:
   version "6.12.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.0.tgz#06d60b96d87b8454a5adaba86e7854da629db4b7"
   integrity sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^6.12.5:
+  version "6.12.6"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
+  integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
   dependencies:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
@@ -7259,6 +7294,14 @@ file-loader@4.3.0:
     loader-utils "^1.2.3"
     schema-utils "^2.5.0"
 
+file-loader@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-6.1.1.tgz#a6f29dfb3f5933a1c350b2dbaa20ac5be0539baa"
+  integrity sha512-Klt8C4BjWSXYQAfhpYYkG4qHNTna4toMHEbWrI5IuVoxbU6uiDKeKAP99R8mmbJi3lvewn/jQBOgU4+NS3tDQw==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
+
 file-name@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/file-name/-/file-name-0.1.0.tgz#12b122f120f9c34dbc176c1ab81a548aced6def7"
@@ -10679,6 +10722,15 @@ loader-utils@^1.0.0, loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2
     big.js "^5.2.2"
     emojis-list "^3.0.0"
     json5 "^1.0.1"
+
+loader-utils@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.0.tgz#e4cace5b816d425a166b5f097e10cd12b36064b0"
+  integrity sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==
+  dependencies:
+    big.js "^5.2.2"
+    emojis-list "^3.0.0"
+    json5 "^2.1.2"
 
 locate-path@^2.0.0:
   version "2.0.0"
@@ -14577,12 +14629,15 @@ react-simple-code-editor@^0.10.0:
   resolved "https://registry.yarnpkg.com/react-simple-code-editor/-/react-simple-code-editor-0.10.0.tgz#73e7ac550a928069715482aeb33ccba36efe2373"
   integrity sha512-bL5W5mAxSW6+cLwqqVWY47Silqgy2DKDTR4hDBrLrUqC5BXc29YVx17l2IZk5v36VcDEq1Bszu2oHm1qBwKqBA==
 
-react-spatial@^1.0.5:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/react-spatial/-/react-spatial-1.0.6.tgz#459bfb785ec0eeb16d5a7f989f98e58e6c28ce91"
-  integrity sha512-p2BSbmfGY5JOGekHVd6ID1iTEwVEeDdf0Ppnvr6bTwC4egJRHo7FVZ16+tH86ZIvPTPj8BemWFZ5mJtXqx5eXw==
+react-spatial@1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/react-spatial/-/react-spatial-1.0.8.tgz#eb6fcf9c34435b937fbad079e1b5e1af1bcc30f4"
+  integrity sha512-BX/s/vRe1vLiw4y851Cq2zIgwpVbUfTHGVc7hBAXdK+H6MKd1dqwBku9VBX5VsN0hy8SaGp8G9emyE0IPoQ2ng==
   dependencies:
+    "@geops/geops-ui" "0.1.4"
+    "@material-ui/core" "^4.11.0"
     abortcontroller-polyfill "1.5.0"
+    file-loader "^6.1.1"
     query-string "6.13.1"
     radians-degrees "1.0.0"
     re-resizable "6.5.4"
@@ -15839,6 +15894,15 @@ schema-utils@^2.5.0, schema-utils@^2.6.0, schema-utils@^2.6.1, schema-utils@^2.6
   dependencies:
     ajv "^6.12.0"
     ajv-keywords "^3.4.1"
+
+schema-utils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.0.0.tgz#67502f6aa2b66a2d4032b4279a2944978a0913ef"
+  integrity sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==
+  dependencies:
+    "@types/json-schema" "^7.0.6"
+    ajv "^6.12.5"
+    ajv-keywords "^3.5.2"
 
 screenfull@^5.0.0:
   version "5.0.2"
@@ -17947,6 +18011,11 @@ uuid@^8.1.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.2.0.tgz#cb10dd6b118e2dada7d0cd9730ba7417c93d920e"
   integrity sha512-CYpGiFTUrmI6OBMkAdjSDM0k5h8SkkiTP4WAjQgDgNB1S3Ou9VBEvr6q0Kv2H1mMk7IWfxYGpMH5sd5AvcIV2Q==
+
+uuid@^8.3.1:
+  version "8.3.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.1.tgz#2ba2e6ca000da60fce5a196954ab241131e05a31"
+  integrity sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==
 
 v8-compile-cache@^2.0.3, v8-compile-cache@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
# How to

<!--  Please provide a test link and quick description how to see the change -->
When using a screenreader, the handicap popup content must be read out loud when opened.
Solution inspired from docu:
https://www.w3.org/TR/wai-aria-practices-1.1/examples/dialog-modal/dialog.html
Ticket: TRAFWART-910

Tested with ORCA on linux & nvaccess on windows

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [ ] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] IE11 tested.
- [x] The title means something for a human being.
- [x] The title contains [WIP] if it's necessary.
- [x] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
