### PR TITLE
CASA zoom button fix

### DIFF
--- a/src/examples/Casa/casa.css
+++ b/src/examples/Casa/casa.css
@@ -14,7 +14,6 @@ https://github.com/oterral/angular-react-test
   border: 1px solid #444;
   box-shadow: none;
   margin: 0;
-  z-index: 10000;
   position: absolute;
   right: 0;
 }
@@ -50,7 +49,14 @@ https://github.com/oterral/angular-react-test
   border: 1px solid #4576a2;
   box-shadow: none;
   color: #4576a2;
-  z-index: 99999;
+}
+
+.casa div.tm-trafimage-maps .wkp-map-controls .rs-zooms-bar .rs-zoom-in:hover {
+  border-bottom: 1px solid #444;
+}
+
+.casa div.tm-trafimage-maps .wkp-map-controls .rs-zooms-bar .rs-zoom-out:hover {
+  border-top: 1px solid #444;
 }
 
 .casa div.tm-trafimage-maps .wkp-map-controls .wkp-fit-extent svg path {


### PR DESCRIPTION
# How to
Using z-Indices on the zoom-btns (used for recoloring the separating border between zoom in&out on hover) caused them to overlap the SBB-App

Updates: 
- z-Indices were removed
- The border separating the zoom in/out btns is now reset to black on hover

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] IE11 tested.
- [x] The title means something for a human being.
- [x] The title contains [WIP] if it's necessary.
- [x] Labels applied. if it's a release? a hotfix?
- [x] Tests added.
