### PR TITLE
Fix CASA examples

### DIFF
--- a/src/layers/TrafimageMapboxLayer/TrafimageMapboxLayer.js
+++ b/src/layers/TrafimageMapboxLayer/TrafimageMapboxLayer.js
@@ -92,8 +92,13 @@ class TrafimageMapboxLayer extends MapboxLayer {
 
     const newStyleUrl = this.createStyleUrl();
 
+    if (this.filters) {
+      // Force loadStyle to apply filters
+      this.loadStyle(newStyleUrl);
+    }
+
     // Don't apply style if not necessary otherwise
-    // it will remove styles apply by MapboxStyleLayer layers.
+    // it will remove styles applied by MapboxStyleLayer layers.
     if (this.styleUrl === newStyleUrl) {
       return;
     }
@@ -183,7 +188,7 @@ class TrafimageMapboxLayer extends MapboxLayer {
           return;
         }
         this.styleUrl = newStyleUrl;
-        const styleFiltered = applyFilters(data, this.options.filters);
+        const styleFiltered = applyFilters(data, this.filters);
         this.mbMap.setStyle(styleFiltered);
         this.mbMap.once('styledata', () => {
           this.onStyleLoaded();


### PR DESCRIPTION
# How to

The filters for the CASA labels layer (overlayers all other layers) was no longer functional, since the filter application was removed in this [commit|https://github.com/geops/trafimage-maps/commit/6f19af92763729b5c4438e9419bec17670019308] (it runs into both of the conditions that return (abort) in setStyleConfig. This caused the labels layer to render all layers, completely overlaying everything else. 

The condition was reinserted to force apply of the filter.

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [ ] IE11 tested.
- [x] The title means something for a human being.
- [x] The title contains [WIP] if it's necessary.
- [x] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
