### PR TITLE
Remove max height on menu item to avoid wrong display on very high re…

### DIFF
--- a/src/components/Menu/MenuItem.scss
+++ b/src/components/Menu/MenuItem.scss
@@ -17,7 +17,6 @@
 .wkp-menu-item {
   border: 2px solid #666;
   background: white;
-  max-height: 1000px;
   margin-top: 5px;
 
   .wkp-menu-item {


### PR DESCRIPTION
…solutions

# How to
On very high resolution, the menu Item max-height breaks the display

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [ ] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [ ] IE11 tested.
- [x] The title means something for a human being.
- [x] The title contains [WIP] if it's necessary.
- [x] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
