### PR TITLE
RouteLayer popupContent Error handling

### DIFF
--- a/src/layers/RouteLayer/RouteLayer.js
+++ b/src/layers/RouteLayer/RouteLayer.js
@@ -56,7 +56,15 @@ class RouteLayer extends CasaLayer {
       ...options,
     });
     this.set('showPopupOnHover', (features = []) => {
-      return features.filter((f) => f.get('route').popupContent);
+      return features.filter((f) => {
+        const { popupContent } = f.get('route');
+        if (popupContent && !Array.isArray(popupContent)) {
+          throw new Error(
+            `Popup content was provided with type ${typeof popupContent}. Please use an array instead (e.g. ['some content', 'more content']).`,
+          );
+        }
+        return popupContent;
+      });
     });
     this.set('popupComponent', 'CasaRoutePopup');
 

--- a/src/layers/RouteLayer/RouteLayer.js
+++ b/src/layers/RouteLayer/RouteLayer.js
@@ -58,9 +58,13 @@ class RouteLayer extends CasaLayer {
     this.set('showPopupOnHover', (features = []) => {
       return features.filter((f) => {
         const { popupContent } = f.get('route');
-        if (popupContent && !Array.isArray(popupContent)) {
+        if (
+          popupContent &&
+          (!Array.isArray(popupContent) ||
+            !popupContent.every((item) => typeof item === 'string'))
+        ) {
           throw new Error(
-            `Popup content was provided with type ${typeof popupContent}. Please use an array instead (e.g. ['some content', 'more content']).`,
+            `Popup content was provided with type ${typeof popupContent}. Please use an array of strings instead (e.g. ['some content', 'more content']).`,
           );
         }
         return popupContent;


### PR DESCRIPTION
1) Added error message handling when passing non-array data in the popupContent for CASA routes. **DONE**

2) The CASA example also does not reload properly when editing the example (vector layer disappears)
-> resolved here: https://github.com/geops/trafimage-maps/pull/883

# How to

# Others

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [ ] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] The title means something for a human being.
- [x] The title contains [WIP] if it's necessary.
- [x] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
