### PR TITLE
Catch and ignore failed API requests

### DIFF
--- a/src/layers/RouteLayer/RouteLayer.js
+++ b/src/layers/RouteLayer/RouteLayer.js
@@ -197,6 +197,9 @@ class RouteLayer extends CasaLayer {
           isEnd,
         });
         return feature;
+      })
+      .catch(() => {
+        // Ignore failed API requests.
       });
   }
 

--- a/src/layers/RouteLayer/RouteLayer.test.js
+++ b/src/layers/RouteLayer/RouteLayer.test.js
@@ -127,6 +127,12 @@ const fetchRoutes = () => {
   fetchMock.once(/8576579/g, routeDataBus);
 };
 
+const fetchRoutesError = () => {
+  /* Mock fetch for each sequence with HTTP errors */
+  fetchMock.once(/8503000/g, 400);
+  fetchMock.once(/8576579/g, 500);
+};
+
 describe('RouteLayer', () => {
   beforeEach(() => {
     onClick = jest.fn();
@@ -229,6 +235,14 @@ describe('RouteLayer', () => {
     const route = await layer.loadRoutes(routes);
 
     expect(route[0]).toBeInstanceOf(Feature);
+  });
+
+  test('should skip failed API requests on loadRoute.', async () => {
+    layer.init(map);
+    fetchRoutesError();
+    const route = await layer.loadRoutes(routes);
+
+    expect(route).toEqual([]);
   });
 
   test('shoud call onClick callbacks and deselect on click.', async () => {


### PR DESCRIPTION
# How to

We want to ignore failed API requests.

# Others

- [x] It's not a hack or at least an unauthorized hack :).
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] The title means something for a human being.
- [x] The title contains [WIP] if it's necessary.
- [ ] Labels applied. if it's a release? a hotfix?
- [x] Tests added.
