### PR TITLE
Add "treppenfrei" exceptions in handicap popup

### DIFF
--- a/src/popups/HandicapPopup/HandicapPopup.js
+++ b/src/popups/HandicapPopup/HandicapPopup.js
@@ -41,8 +41,14 @@ function HandicapPopup({ feature }) {
   // build string for equipment
   const equipment = [];
 
+  const treppenfreiString = `${t('treppenfrei')}${
+    properties[bfEquipmentExceptions.rampe]
+      ? ` (${properties[bfEquipmentExceptions.rampe]})`
+      : ''
+  }`;
+
   equipment.unshift(
-    properties.treppenfrei ? t('treppenfrei') : t('nicht treppenfrei'),
+    properties.treppenfrei ? treppenfreiString : t('nicht treppenfrei'),
   );
 
   Object.keys(bfEquipmentExceptions).forEach((key) => {


### PR DESCRIPTION
# How to
In Handicap topic station popup, currently the "treppenfrei" equipment string does not include the exceptions in brackets.

**Fix**: The exceptions string was added to the popup.

**Test**: 

- In the [netlify review app](https://deploy-preview-893--dev-trafimage-maps.netlify.app/), switch to Handicap topic and click on Neuchatel station. 
- In the station equipment the "treppenfrei" should be followed by "(ausser Gleis 1)" (in German only) and should be the same as in the "Rampe" equipment. Other stations where this can be tested are e.g. Solothurn, Villeneuve or St-Maurice.
- Most other stations with "treppenfrei" should not render any brackets with exceptions.

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] The title means something for a human being.
- [x] The title contains [WIP] if it's necessary.
- [ ] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
