### PR TITLE
Handicap popup: Remove ramp exception duplicate

### DIFF
--- a/src/popups/HandicapPopup/HandicapPopup.js
+++ b/src/popups/HandicapPopup/HandicapPopup.js
@@ -60,7 +60,6 @@ function HandicapPopup({ feature }) {
   );
 
   Object.keys(bfEquipmentExceptions).forEach((key) => {
-    console.log(key, properties[key]);
     if (properties[key]) {
       let str = t(key);
 

--- a/src/popups/HandicapPopup/HandicapPopup.js
+++ b/src/popups/HandicapPopup/HandicapPopup.js
@@ -50,7 +50,7 @@ function HandicapPopup({ feature }) {
   const equipment = [];
 
   const treppenfreiString = `${t('treppenfrei')}${
-    properties[bfEquipmentExceptions.rampe]
+    properties[bfEquipmentExceptions.rampe] && !properties.rampe
       ? ` (${properties[bfEquipmentExceptions.rampe]})`
       : ''
   }`;
@@ -60,6 +60,7 @@ function HandicapPopup({ feature }) {
   );
 
   Object.keys(bfEquipmentExceptions).forEach((key) => {
+    console.log(key, properties[key]);
     if (properties[key]) {
       let str = t(key);
 


### PR DESCRIPTION
# How to

**Issue:** When treppenfrei=true, rampe=true and rampe_ausnahme is defined the ramp exception is shown twice (after "Treppenfrei" string and "Rampe" string)

**Solution:** The ramp exception after "Treppenfrei" is only displayed when ramp=false.

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] The title means something for a human being.
- [x] The title contains [WIP] if it's necessary.
- [x] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
