### PR TITLE
Replace geoserver use by vector tiles

### DIFF
--- a/src/config/layers.js
+++ b/src/config/layers.js
@@ -8,7 +8,6 @@ import { register } from 'ol/proj/proj4';
 import { Layer, TrajservLayer } from 'mobility-toolbox-js/ol';
 import { TrajservAPI } from 'mobility-toolbox-js/api';
 import MapboxStyleLayer from '../layers/MapboxStyleLayer';
-import TrafimageGeoServerWMSLayer from '../layers/TrafimageGeoServerWMSLayer';
 import ParksLayer from '../layers/ParksLayer';
 import TrafimageMapboxLayer from '../layers/TrafimageMapboxLayer';
 import KilometrageLayer from '../layers/KilometrageLayer';
@@ -319,26 +318,15 @@ export const buslines = new MapboxStyleLayer({
   },
 });
 
-export const gemeindegrenzen = new TrafimageGeoServerWMSLayer({
+export const gemeindegrenzen = new MapboxStyleLayer({
   name: 'ch.sbb.ch_gemeinden',
+  mapboxLayer: dataLayer,
   visible: false,
-  olLayer: new TileLayer({
-    source: new TileWMSSource({
-      crossOrigin: 'anonymous',
-      params: {
-        layers: 'trafimage:gemeindegrenzen',
-        STYLES: 'gemeindegrenzen_netzkarte',
-      },
-      tileGrid: new TileGrid({
-        extent: projectionExtent,
-        resolutions: LayerHelper.getMapResolutions(),
-        matrixIds: LayerHelper.getMapResolutions().map((r, i) => `${i}`),
-      }),
-    }),
-  }),
+  isQueryable: false,
+  styleLayersFilter: ({ metadata }) =>
+    metadata && metadata['trafimage.filter'] === 'municipality_borders',
   properties: {
     hasInfos: true,
-    featureInfoEventTypes: [],
     description: 'ch.sbb.ch_gemeinden-desc',
   },
 });


### PR DESCRIPTION
# How to

<!--  Please provide a test link and quick description how to see the change -->
 - Open [?baselayers=ch.sbb.netzkarte,ch.sbb.netzkarte.dark,ch.sbb.netzkarte.luftbild.group,ch.sbb.netzkarte.landeskarte,ch.sbb.netzkarte.landeskarte.grau&lang=de&layers=ch.sbb.ch_gemeinden&x=798059.4&y=5912573.3&z=12.59](?baselayers=ch.sbb.netzkarte,ch.sbb.netzkarte.dark,ch.sbb.netzkarte.luftbild.group,ch.sbb.netzkarte.landeskarte,ch.sbb.netzkarte.landeskarte.grau&lang=de&layers=ch.sbb.ch_gemeinden&x=798059.4&y=5912573.3&z=12.59)
 - Try to hide /show the Municipalities border layer.

---> You should see or not the municipalities border.

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] The title means something for a human being.
- [x] The title contains [WIP] if it's necessary.
- [x] Labels applied. if it's a release? a hotfix?
- [x] Tests added.
