### PR TITLE
Fix lines Search

### DIFF
--- a/src/components/Search/SearchService.js
+++ b/src/components/Search/SearchService.js
@@ -60,6 +60,7 @@ class SearchService {
       ? this.searches[item.section].getFeature(item, { featureProjection })
       : this.highlightFeature;
 
+    console.log(feature);
     if (feature) {
       this.highlightLayer.getSource().addFeature(feature);
       if (persistent) {

--- a/src/components/Search/SearchService.js
+++ b/src/components/Search/SearchService.js
@@ -60,7 +60,6 @@ class SearchService {
       ? this.searches[item.section].getFeature(item, { featureProjection })
       : this.highlightFeature;
 
-    console.log(feature);
     if (feature) {
       this.highlightLayer.getSource().addFeature(feature);
       if (persistent) {

--- a/src/searches/Lines/Lines.js
+++ b/src/searches/Lines/Lines.js
@@ -1,6 +1,11 @@
 import React from 'react';
 import { Style, Circle, Fill, Stroke as OLStroke } from 'ol/style';
-import { MultiLineString, GeometryCollection } from 'ol/geom';
+import {
+  MultiLineString,
+  GeometryCollection,
+  MultiPoint,
+  Point,
+} from 'ol/geom';
 import GeoJSON from 'ol/format/GeoJSON';
 
 import Search from '../Search';
@@ -54,6 +59,19 @@ class Lines extends Search {
               color,
               width: 10,
             }),
+            image:
+              geometry.getGeometries &&
+              geometry
+                .getGeometries()
+                .find(
+                  (geom) => geom instanceof MultiPoint || geom instanceof Point,
+                ) &&
+              new Circle({
+                radius: 10,
+                fill: new Fill({
+                  color,
+                }),
+              }),
           })
         : new Style({
             geometry,

--- a/src/searches/Lines/Lines.js
+++ b/src/searches/Lines/Lines.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Style, Circle, Fill, Stroke as OLStroke } from 'ol/style';
-import { MultiLineString } from 'ol/geom';
+import { MultiLineString, GeometryCollection } from 'ol/geom';
 import GeoJSON from 'ol/format/GeoJSON';
 
 import Search from '../Search';
@@ -10,7 +10,9 @@ const lineMeasuresRegExp = new RegExp(
   '([0-9]*)\\s*([0-9]+\\.?[0-9]*)\\-([0-9]*\\.?[0-9]*)',
 );
 
-const lineKilometerRegExp = new RegExp('^([0-9]+)\\s+([0-9]+\\.?[0-9]+)$');
+const lineKilometerRegExp = new RegExp(
+  '^([0-9]+)(\\s)(\\+)?(\\s+)?([0-9]+(\\.[0-9]+)?)$',
+);
 
 const color = 'rgba(0,61,155,0.5)';
 
@@ -44,7 +46,8 @@ class Lines extends Search {
           featureProjection: 'EPSG:3857',
         }) || f.getGeometry();
 
-      return geometry instanceof MultiLineString
+      return geometry instanceof MultiLineString ||
+        geometry instanceof GeometryCollection
         ? new Style({
             geometry,
             stroke: new OLStroke({
@@ -70,7 +73,7 @@ class Lines extends Search {
   search(value) {
     let params = `line=${encodeURIComponent(value)}`;
     if (lineKilometerRegExp.test(value)) {
-      const [, line, km] = value.match(lineKilometerRegExp);
+      const [, line, , , , km] = value.match(lineKilometerRegExp);
       params = `line=${line}&km=${km}`;
     }
     if (lineMeasuresRegExp.test(value)) {
@@ -81,7 +84,9 @@ class Lines extends Search {
       process.env.REACT_APP_SEARCH_URL || 'https://maps.trafimage.ch';
     return fetch(`${baseUrl}/search/lines?${params}`)
       .then((data) => data.json())
-      .then((featureCollection) => featureCollection.features)
+      .then((featureCollection) => {
+        return featureCollection.features;
+      })
       .catch(() => {
         return [];
       });

--- a/src/searches/Lines/Lines.test.js
+++ b/src/searches/Lines/Lines.test.js
@@ -34,11 +34,29 @@ describe('Lines', () => {
     });
   });
 
+  describe('should not insert the km parameter in a km search request', () => {
+    test('with no subsequent whitespace after line number (500+50)', async () => {
+      await linesSearch.search('500+50');
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://maps.trafimage.ch/search/lines?line=500%2B50',
+      );
+    });
+  });
+
   describe('should insert the km and km_end parameters correctly in a line segment search request', () => {
     test('with 500 10-50', async () => {
       await linesSearch.search('500 10-50');
       expect(fetchMock).toHaveBeenCalledWith(
         'https://maps.trafimage.ch/search/lines?line=500&km=10&km_end=50',
+      );
+    });
+  });
+
+  describe('should not insert the km and km_end parameters correctly in a line segment search request', () => {
+    test('with a wrong pattern (500 50 -80)', async () => {
+      await linesSearch.search('500 50 -80');
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://maps.trafimage.ch/search/lines?line=500%2050%20-80',
       );
     });
   });

--- a/src/searches/Lines/Lines.test.js
+++ b/src/searches/Lines/Lines.test.js
@@ -1,0 +1,45 @@
+import Lines from './Lines';
+
+const linesSearch = new Lines();
+
+const fetchMock = jest
+  .spyOn(global, 'fetch')
+  .mockImplementation(() =>
+    Promise.resolve({ json: () => Promise.resolve([]) }),
+  );
+
+describe('Lines', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('should insert the km parameter correctly in a km search request', () => {
+    test('with 500 +50', async () => {
+      await linesSearch.search('500 +50');
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://maps.trafimage.ch/search/lines?line=500&km=50',
+      );
+    });
+    test('with 500 50', async () => {
+      await linesSearch.search('500 50');
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://maps.trafimage.ch/search/lines?line=500&km=50',
+      );
+    });
+    test('with 500 +  50', async () => {
+      await linesSearch.search('500 +  50');
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://maps.trafimage.ch/search/lines?line=500&km=50',
+      );
+    });
+  });
+
+  describe('should insert the km and km_end parameters correctly in a line segment search request', () => {
+    test('with 500 10-50', async () => {
+      await linesSearch.search('500 10-50');
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://maps.trafimage.ch/search/lines?line=500&km=10&km_end=50',
+      );
+    });
+  });
+});


### PR DESCRIPTION
# How to

The Search for line kilometre points is not working and the Search line segments works but doesn't highlight the line on the map.

Fix: 
- Updated the faulty regex for kilometre search (valid searches for line 500 and km 50.1: 500 50.1, 500 +50.1, 500 + 50.1)
- Added Point highlighting when Point is returned (e.g. a kilometer)
- Fixed line highlighting on map by accepting GeometryCollections (as well as MultiLineString)

Test: 
- **500 50.1**, **500 +50.1**, **500 + 50.1** should return a point in lines search results and highlight it on the map on hover
- **500 1-80** should return a line segment in the lines results and highlight the line on hover  

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] The title means something for a human being.
- [x] The title contains [WIP] if it's necessary.
- [x] Labels applied. if it's a release? a hotfix?
- [x] Tests added.
