### PR TITLE
Do not block the map when the overlay is open

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trafimage-maps",
-  "version": "1.5.41",
+  "version": "1.5.42-beta.1",
   "private": true,
   "main": "build/bundle.js",
   "proxy": "http://127.0.0.1:8000",

--- a/src/components/Overlay/Overlay.js
+++ b/src/components/Overlay/Overlay.js
@@ -7,6 +7,9 @@ import FeatureInformation from '../FeatureInformation';
 import { setFeatureInfo } from '../../model/app/actions';
 
 const useStyles = makeStyles({
+  drawerRoot: {
+    position: 'relative !important',
+  },
   drawer: {
     '& .wkp-feature-information': {
       height: '100%',
@@ -107,6 +110,7 @@ const Overlay = ({ elements, appBaseUrl, staticFilesUrl }) => {
           isMobile ? classes.drawerMobile : classes.drawerDesktop
         }`}
         classes={{
+          root: classes.drawerRoot,
           paper: isMobile
             ? ''
             : `${[


### PR DESCRIPTION
Fix overlay on mobile: Do not block the map when the overlay is open

# How to

<!--  Please provide a test link and quick description how to see the change -->

1. Open the topic Netzentwicklung in the emulator*
2. Click on a colored line 
=> the overlay opens at the bottom
3. Try to interact with the map (pan, zoom, click on features)
=> The Interaction must work.

* Testing on a mobile device did not work for me as the overlay does not open at all for the netlify app, the same for https://github.com/geops/trafimage-maps/pull/928


# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [ ] It's not a hack or at least an unauthorized hack :). - `important` used for css
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] The title means something for a human being.
- [ ] The title contains [WIP] if it's necessary.
- [ ] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
