### PR TITLE
Deactivate completely pointer events when popup element is disabled

### DIFF
--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -197,10 +197,16 @@ class Map extends PureComponent {
       dispatchSetFeatureInfo,
       dispatchSetSearchOpen,
       dispatchHtmlEvent,
+      activeTopic,
+      showPopups,
     } = this.props;
 
-    const layers = this.getQueryableLayers('singleclick');
+    // If there is no popup to display just ignore the click event.
+    if (!showPopups || !activeTopic?.elements?.popup) {
+      return;
+    }
 
+    const layers = this.getQueryableLayers('singleclick');
     layerService
       .getFeatureInfoAtCoordinate(coordinate, layers)
       .then((featureInfos) => {

--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -30,6 +30,7 @@ const propTypes = {
   layers: PropTypes.arrayOf(PropTypes.instanceOf(Layer)),
   map: PropTypes.instanceOf(OLMap).isRequired,
   layerService: PropTypes.instanceOf(LayerService).isRequired,
+  activeTopic: PropTypes.shape().isRequired,
   resolution: PropTypes.number,
   zoom: PropTypes.number,
   showPopups: PropTypes.bool,
@@ -128,57 +129,65 @@ class Map extends PureComponent {
 
   onPointerMove(evt) {
     const { map, coordinate } = evt;
-    const { layerService, featureInfo, dispatchSetFeatureInfo, showPopups } =
-      this.props;
+    const {
+      layerService,
+      featureInfo,
+      dispatchSetFeatureInfo,
+      showPopups,
+      activeTopic,
+    } = this.props;
 
     if (document.activeElement !== map.getTargetElement()) {
       map.getTargetElement().focus();
     }
 
-    if (map.getView().getInteracting() || map.getView().getAnimating()) {
+    if (
+      !showPopups ||
+      !activeTopic?.elements?.popup ||
+      map.getView().getInteracting() ||
+      map.getView().getAnimating()
+    ) {
       return;
     }
 
-    if (showPopups) {
-      const layers = this.getQueryableLayers('pointermove');
-      layerService
-        .getFeatureInfoAtCoordinate(coordinate, layers)
-        .then((newInfos) => {
-          let infos = newInfos.filter(({ features }) => features.length);
-          map.getTarget().style.cursor = infos.length ? 'pointer' : 'auto';
+    const layers = this.getQueryableLayers('pointermove');
+    layerService
+      .getFeatureInfoAtCoordinate(coordinate, layers)
+      .then((newInfos) => {
+        let infos = newInfos.filter(({ features }) => features.length);
+        map.getTarget().style.cursor = infos.length ? 'pointer' : 'auto';
 
-          const isClickInfoOpen =
-            featureInfo.length &&
-            featureInfo.every(
+        const isClickInfoOpen =
+          featureInfo.length &&
+          featureInfo.every(
+            ({ layer }) =>
+              layer.get('popupComponent') && !layer.get('showPopupOnHover'),
+          );
+
+        // don't continue if there's a popup that was opened by click
+        if (!isClickInfoOpen) {
+          infos = infos
+            .filter(
               ({ layer }) =>
-                layer.get('popupComponent') && !layer.get('showPopupOnHover'),
-            );
+                layer.get('showPopupOnHover') && layer.get('popupComponent'),
+            )
+            .map((info) => {
+              /* Apply showPopupOnHover function if defined to further filter features */
+              const showPopupOnHover = info.layer.get('showPopupOnHover');
+              if (typeof showPopupOnHover === 'function') {
+                return {
+                  ...info,
+                  features: info.layer.get('showPopupOnHover')(info.features),
+                };
+              }
+              return info;
+            });
 
-          // don't continue if there's a popup that was opened by click
-          if (!isClickInfoOpen) {
-            infos = infos
-              .filter(
-                ({ layer }) =>
-                  layer.get('showPopupOnHover') && layer.get('popupComponent'),
-              )
-              .map((info) => {
-                /* Apply showPopupOnHover function if defined to further filter features */
-                const showPopupOnHover = info.layer.get('showPopupOnHover');
-                if (typeof showPopupOnHover === 'function') {
-                  return {
-                    ...info,
-                    features: info.layer.get('showPopupOnHover')(info.features),
-                  };
-                }
-                return info;
-              });
-
-            if (!Map.isSameFeatureInfo(featureInfo, infos)) {
-              dispatchSetFeatureInfo(infos);
-            }
+          if (!Map.isSameFeatureInfo(featureInfo, infos)) {
+            dispatchSetFeatureInfo(infos);
           }
-        });
-    }
+        }
+      });
   }
 
   onSingleClick(evt) {
@@ -294,6 +303,7 @@ const mapStateToProps = (state) => ({
   zoom: state.map.zoom,
   maxExtent: state.map.maxExtent,
   showPopups: state.app.showPopups,
+  activeTopic: state.app.activeTopic,
 });
 
 const mapDispatchToProps = {

--- a/src/components/TopicElements/TopicElements.js
+++ b/src/components/TopicElements/TopicElements.js
@@ -74,8 +74,12 @@ const getComponents = (defaultComponents, elementsToDisplay) =>
 function TopicElements({ history, appBaseUrl, loginUrl, staticFilesUrl }) {
   const ref = useRef(null);
   const dispatch = useDispatch();
-  const { activeTopic, layerService, map } = useSelector((state) => state.app);
+  const { t } = useTranslation();
+  const activeTopic = useSelector((state) => state.app.activeTopic);
+  const layerService = useSelector((state) => state.app.layerService);
+  const map = useSelector((state) => state.app.map);
   const [tabFocus, setTabFocus] = useState(false);
+
   useEffect(() => {
     const unfocusTab = () => setTabFocus(false);
     const focusTab = (e) => e.which === 9 && setTabFocus(true);
@@ -86,7 +90,7 @@ function TopicElements({ history, appBaseUrl, loginUrl, staticFilesUrl }) {
       document.removeEventListener('keydown', focusTab);
     };
   });
-  const { t } = useTranslation();
+
   if (!activeTopic) {
     return null;
   }


### PR DESCRIPTION
# How to

<!--  Please provide a test link and quick description how to see the change -->
Open an example of the doc and set the topic.elements.popup property to false. There should not be highlight and select effect.

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] The title means something for a human being.
- [x] The title contains [WIP] if it's necessary.
- [x] Labels applied. if it's a release? a hotfix?
- [x] Tests added.
