### PR TITLE
Improve Select

### DIFF
--- a/cypress/integration/Header.spec.js
+++ b/cypress/integration/Header.spec.js
@@ -2,12 +2,12 @@
 
 const expectBaseLayersSelectVisible = () => {
   cy.get('.rs-base-layer-switcher').should('be.hidden');
-  cy.get('.wkp-base-layers-select').should('be.visible');
+  cy.get('[data-cy=baselayer-select]').should('be.visible');
 };
 
 const expectBaseLayersSwitcherVisible = () => {
   cy.get('.rs-base-layer-switcher').should('be.visible');
-  cy.get('.wkp-base-layers-select').should('be.hidden');
+  cy.get('[data-cy=baselayer-select]').should('be.hidden');
 };
 const expectDevPortalLinkVisible = () => {
   cy.get('.wkp-dev-portal-link').should('be.visible');

--- a/src/components/LanguageSelect/LanguageSelect.js
+++ b/src/components/LanguageSelect/LanguageSelect.js
@@ -58,10 +58,6 @@ const LanguageSelect = () => {
   const dispatch = useDispatch();
   const language = useSelector((state) => state.app.language);
   const screenWidth = useSelector((state) => state.app.screenWidth);
-  const isTabletWidth = useMemo(
-    () => ['m'].includes(screenWidth),
-    [screenWidth],
-  );
   const isMobileWidth = useMemo(
     () => ['xs', 's'].includes(screenWidth),
     [screenWidth],
@@ -112,24 +108,7 @@ const LanguageSelect = () => {
         onChange={onSelectChange}
         className={classes.input}
         classes={{ outlined: classes.select, icon: classes.expandIcon }}
-        MenuProps={{
-          'data-cy': 'lang-select-options',
-          getContentAnchorEl: null,
-          anchorOrigin: {
-            vertical: 'top',
-            horizontal: 'left',
-          },
-          PaperProps: {
-            style: {
-              border: `1px solid #888`,
-              borderTop: '1px solid rgba(0, 0, 0, 0.1)',
-              borderRadius: 0,
-              marginTop: isMobileWidth || isTabletWidth ? 28 : 38,
-              minWidth: isMobileWidth ? 53 : 118,
-              top: '26 !important',
-            },
-          },
-        }}
+        MenuProps={{ 'data-cy': 'lang-select-options' }}
         variant="outlined"
       >
         {langOptions}

--- a/src/components/ProjectionSelect/ProjectionSelect.js
+++ b/src/components/ProjectionSelect/ProjectionSelect.js
@@ -73,18 +73,11 @@ const ProjectionSelect = ({ projections }) => {
       className={classes.input}
       classes={{ outlined: classes.select }}
       MenuProps={{
-        anchorPosition: {
-          left: 0,
-          top: 0,
-        },
         PaperProps: {
           style: {
-            marginRight: 2,
-            border: `1px solid #888`,
+            borderTop: `1px solid #888`,
             borderBottom: '1px solid rgba(0, 0, 0, 0.1)',
-            borderRadius: 0,
             marginTop: -19,
-            minWidth: 148,
           },
         },
       }}

--- a/src/components/TopicMenu/TopicMenu.js
+++ b/src/components/TopicMenu/TopicMenu.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import { FaLock } from 'react-icons/fa';
 import LayerTree from 'react-spatial/components/LayerTree';
 import LayerService from 'react-spatial/LayerService';
-import { Select, MenuItem } from '@material-ui/core';
+import { withStyles, MenuItem } from '@material-ui/core';
 import Collapsible from '../Collapsible';
 import filters from '../../filters';
 import {
@@ -14,8 +14,20 @@ import {
   setFeatureInfo,
   updateDrawEditLink,
 } from '../../model/app/actions';
+import Select from '../Select/Select';
 import InfosButton from '../InfosButton';
 import TopicInfosButton from '../TopicInfosButton';
+
+const styles = (theme) => ({
+  baselayerSelect: {
+    margin: '4px 20px 5px 23px',
+    height: 30,
+    width: 'calc(100% - 42px)',
+    [theme.breakpoints.up('lg')]: {
+      display: 'none',
+    },
+  },
+});
 
 const propTypes = {
   topic: PropTypes.shape().isRequired,
@@ -28,6 +40,9 @@ const propTypes = {
   // mapDispatchToProps
   dispatchSetActiveTopic: PropTypes.func.isRequired,
   dispatchSetFeatureInfo: PropTypes.func.isRequired,
+
+  // Mui
+  classes: PropTypes.object.isRequired,
 
   t: PropTypes.func.isRequired,
 };
@@ -73,7 +88,8 @@ class TopicMenu extends PureComponent {
   }
 
   render() {
-    const { t, layerService, topic, activeTopic, menuOpen } = this.props;
+    const { t, layerService, topic, activeTopic, menuOpen, classes } =
+      this.props;
     const { isCollapsed, currentBaseLayerKey } = this.state;
     let layerTree = null;
     const TopicMenuBottom = topic.topicMenuBottom;
@@ -180,8 +196,7 @@ class TopicMenu extends PureComponent {
           <Collapsible isCollapsed={isCollapsed}>
             {topic.key === activeTopic.key && baseLayers.length > 1 && (
               <Select
-                variant="outlined"
-                className="wkp-base-layers-select"
+                className={classes.baselayerSelect}
                 value={
                   currentBaseLayerKey ||
                   currentBaseLayer.name ||
@@ -198,6 +213,15 @@ class TopicMenu extends PureComponent {
                     currentBaseLayerKey: baseLayer.name || baseLayer.key,
                   });
                 }}
+                MenuProps={{
+                  PaperProps: {
+                    style: {
+                      padding: 0,
+                      marginTop: -10,
+                    },
+                  },
+                }}
+                data-cy="baselayer-select"
               >
                 {baseLayers.map(({ name, key }) => {
                   const value = name || key;
@@ -237,4 +261,5 @@ const mapDispatchToProps = {
 export default compose(
   withTranslation(),
   connect(mapStateToProps, mapDispatchToProps),
+  withStyles(styles, { withTheme: true }),
 )(TopicMenu);

--- a/src/components/TopicMenu/TopicMenu.scss
+++ b/src/components/TopicMenu/TopicMenu.scss
@@ -146,21 +146,6 @@
   .wkp-topic-content {
     transition: max-height 0.3s ease, margin 0.3s ease;
     max-height: 2500px;
-
-    .wkp-base-layers-select {
-      margin: 4px 20px 5px 23px;
-      height: 30px;
-      width: calc(100% - 42px);
-      display: none;
-
-      & .MuiSelect-root:focus {
-        background-color: transparent;
-      }
-
-      & .MuiOutlinedInput-input {
-        padding: 8px 14px;
-      }
-    }
   }
 }
 

--- a/src/components/TrafimageMaps/TrafimageMaps.scss
+++ b/src/components/TrafimageMaps/TrafimageMaps.scss
@@ -237,10 +237,6 @@
       display: none;
     }
 
-    .wkp-base-layers-select {
-      display: block;
-    }
-
     .wkp-header {
       height: 55px;
     }

--- a/src/config/layers.js
+++ b/src/config/layers.js
@@ -1597,9 +1597,9 @@ const mapsGeoAdminSchutzgebieteLayerKeys = [
 export const beleuchtungstaerkenSchutzgebieteLayer = new MapsGeoAdminLayer({
   name: 'ch.sbb.beleuchtungsstaerken.bafu-schutzgebiete.group',
   visible: false,
-  children: [
-    ...mapsGeoAdminSchutzgebieteLayerKeys.map(createMapsGeoAdminStyleLayer),
-  ],
+  children: mapsGeoAdminSchutzgebieteLayerKeys.map(
+    createMapsGeoAdminStyleLayer,
+  ),
   properties: {
     featureInfoEventTypes: ['singleclick'],
     popupComponent: 'MapsGeoAdminPopup',
@@ -1626,9 +1626,9 @@ const mapsGeoAdminBundesinventareLayerKeys = [
 export const beleuchtungstaerkenBundesInventareLayer = new MapsGeoAdminLayer({
   name: 'ch.sbb.beleuchtungsstaerken.bafu-bundesinventare.group',
   visible: false,
-  children: [
-    ...mapsGeoAdminBundesinventareLayerKeys.map(createMapsGeoAdminStyleLayer),
-  ],
+  children: mapsGeoAdminBundesinventareLayerKeys.map(
+    createMapsGeoAdminStyleLayer,
+  ),
   properties: {
     featureInfoEventTypes: ['singleclick'],
     popupComponent: 'MapsGeoAdminPopup',

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -83,7 +83,7 @@
   "ch.bafu.schutzgebiete-smaragd": "Sites Emeraude",
   "ch.bafu.bundesinventare-amphibien_wanderobjekte": "Sites de reproduction de batraciens - Objets itinérants",
   "ch.bafu.bundesinventare-amphibien": "Sites de reproduction de batraciens - Objets fixes",
-  "ch.bafu.bundesinventare-amphibien_anhang4": "Amphibienlaichgebiete - Annexe 3",
+  "ch.bafu.bundesinventare-amphibien_anhang4": "Sites de reproduction de batraciens - Annexe 3",
   "ch.bafu.bundesinventare-auen": "Zones alluviales",
   "ch.bafu.bundesinventare-auen_anhang2": "Zones alluviales - Annexe 2",
   "ch.bafu.bundesinventare-flachmoore": "Bas-marais",


### PR DESCRIPTION
# How to

Updates:
- Fixed the hideOutline MUI error message by deleting the prop before injecting them
- Using deepMerge to merge the MenuProps. MenuProps injected into the local Select component are deep merged with a default MenuProps object inside the component. This saves us from applying a lot of code when calling the component.
- Using TransintionProps _onEnter_ (as suggested by MUI, since PaperProps _onEnter_ is deprecated). By using this property in the default MenuProps object the dropdown width is now always calculated automatically

# Others

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] The title means something for a human being.
- [x] The title contains [WIP] if it's necessary.
- [x] Labels applied. if it's a release? a hotfix?
- [x] Tests added.
