### PR TITLE
Use overlay by default instead of popup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "trafimage-maps",
   "description": "trafimage-maps web component",
-  "version": "1.7.7",
+  "version": "1.7.8-beta.1",
   "private": true,
   "main": "build/bundle.js",
   "proxy": "http://127.0.0.1:8000",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "trafimage-maps",
   "description": "trafimage-maps web component",
-  "version": "1.7.8-beta.1",
+  "version": "1.7.8-beta.2",
   "private": true,
   "main": "build/bundle.js",
   "proxy": "http://127.0.0.1:8000",

--- a/public/index.html
+++ b/public/index.html
@@ -160,7 +160,7 @@
       zoom="8"
       center="[810000, 5900000]"
       appName="wkp"
-      activeTopicKey="ch.sbb.beleuchtungsstaerken"
+      activeTopicKey="ch.sbb.netzkarte"
     ></trafimage-maps>
     <!-- zoom="14" center="[810000, 5900000]" -->
     <button

--- a/public/index.html
+++ b/public/index.html
@@ -160,7 +160,7 @@
       zoom="8"
       center="[810000, 5900000]"
       appName="wkp"
-      activeTopicKey="ch.sbb.infrastruktur"
+      activeTopicKey="ch.sbb.beleuchtungsstaerken"
     ></trafimage-maps>
     <!-- zoom="14" center="[810000, 5900000]" -->
     <button

--- a/public/index.html
+++ b/public/index.html
@@ -160,7 +160,7 @@
       zoom="8"
       center="[810000, 5900000]"
       appName="wkp"
-      activeTopicKey="ch.sbb.netzkarte"
+      activeTopicKey="ch.sbb.zweitausbildung"
     ></trafimage-maps>
     <!-- zoom="14" center="[810000, 5900000]" -->
     <button

--- a/public/index.html
+++ b/public/index.html
@@ -160,7 +160,7 @@
       zoom="8"
       center="[810000, 5900000]"
       appName="wkp"
-      activeTopicKey="ch.sbb.zweitausbildung"
+      activeTopicKey="ch.sbb.construction"
     ></trafimage-maps>
     <!-- zoom="14" center="[810000, 5900000]" -->
     <button

--- a/public/index.html
+++ b/public/index.html
@@ -160,7 +160,7 @@
       zoom="8"
       center="[810000, 5900000]"
       appName="wkp"
-      activeTopicKey="ch.sbb.tarifverbundkarte.public"
+      activeTopicKey="ch.sbb.infrastruktur"
     ></trafimage-maps>
     <!-- zoom="14" center="[810000, 5900000]" -->
     <button

--- a/public/index.html
+++ b/public/index.html
@@ -160,7 +160,7 @@
       zoom="8"
       center="[810000, 5900000]"
       appName="wkp"
-      activeTopicKey="ch.sbb.construction"
+      activeTopicKey="ch.sbb.tarifverbundkarte.public"
     ></trafimage-maps>
     <!-- zoom="14" center="[810000, 5900000]" -->
     <button

--- a/src/components/FeatureInformation/FeatureInformation.js
+++ b/src/components/FeatureInformation/FeatureInformation.js
@@ -183,7 +183,7 @@ const FeatureInformation = ({ featureInfo, appBaseUrl, staticFilesUrl }) => {
       map.getView().fit(extent, {
         padding: isMobile ? [0, 0, 250, 0] : [0, 400, 0, 0],
         maxZoom: map.getView().getZoom(), // only pan
-        duration: 1000,
+        duration: 500,
       });
     }
   }, [map, isMobile, featureIndex, infoIndexed]);

--- a/src/config/layers.js
+++ b/src/config/layers.js
@@ -846,6 +846,7 @@ export const betriebsRegionen = new MapboxStyleLayer({
   queryRenderedLayersFilter: ({ id }) => /pattern_/.test(id),
   properties: {
     hasInfos: true,
+    useOverlay: true,
     popupComponent: 'BetriebsRegionenPopup',
     layerInfoComponent: 'BetriebsRegionenLayerInfo',
   },

--- a/src/config/layers.js
+++ b/src/config/layers.js
@@ -478,6 +478,7 @@ export const kilometrageLayer = new KilometrageLayer({
   properties: {
     hideInLegend: true,
     featureInfoEventTypes: ['singleclick'],
+    useOverlay: false,
     popupComponent: 'KilometragePopup',
   },
 });
@@ -845,6 +846,7 @@ export const betriebsRegionen = new MapboxStyleLayer({
   queryRenderedLayersFilter: ({ id }) => /pattern_/.test(id),
   properties: {
     hasInfos: true,
+    useOverlay: true,
     popupComponent: 'BetriebsRegionenPopup',
     layerInfoComponent: 'BetriebsRegionenLayerInfo',
   },
@@ -859,6 +861,7 @@ export const betriebsRegionenVisible = new MapboxStyleLayer({
   queryRenderedLayersFilter: ({ id }) => /pattern_/.test(id),
   properties: {
     hasInfos: true,
+    useOverlay: true,
     popupComponent: 'BetriebsRegionenPopup',
     layerInfoComponent: 'BetriebsRegionenLayerInfo',
   },

--- a/src/config/layers.js
+++ b/src/config/layers.js
@@ -846,7 +846,6 @@ export const betriebsRegionen = new MapboxStyleLayer({
   queryRenderedLayersFilter: ({ id }) => /pattern_/.test(id),
   properties: {
     hasInfos: true,
-    useOverlay: true,
     popupComponent: 'BetriebsRegionenPopup',
     layerInfoComponent: 'BetriebsRegionenLayerInfo',
   },

--- a/src/config/layers.js
+++ b/src/config/layers.js
@@ -515,6 +515,7 @@ export const constrAusbau = new AusbauLayer({
       properties: {
         hasInfos: true,
         layerInfoComponent: 'ConstructionLayerInfo',
+        useOverlay: true,
         popupComponent: 'ConstructionPopup',
         construction: {
           art: 'Ausbau',
@@ -532,6 +533,7 @@ export const constrAusbau = new AusbauLayer({
       properties: {
         hasInfos: true,
         layerInfoComponent: 'ConstructionLayerInfo',
+        useOverlay: true,
         popupComponent: 'ConstructionPopup',
         construction: {
           art: 'Ausbau',
@@ -549,6 +551,7 @@ export const constrAusbau = new AusbauLayer({
       properties: {
         hasInfos: true,
         layerInfoComponent: 'ConstructionLayerInfo',
+        useOverlay: true,
         popupComponent: 'ConstructionPopup',
         construction: {
           art: 'Ausbau',
@@ -566,6 +569,7 @@ export const constrAusbau = new AusbauLayer({
       properties: {
         hasInfos: true,
         layerInfoComponent: 'ConstructionLayerInfo',
+        useOverlay: true,
         popupComponent: 'ConstructionPopup',
         construction: {
           art: 'Ausbau',
@@ -596,6 +600,7 @@ export const constrUnterhalt = new Layer({
       properties: {
         hasInfos: true,
         layerInfoComponent: 'ConstructionLayerInfo',
+        useOverlay: true,
         popupComponent: 'ConstructionPopup',
         construction: {
           art: 'Unterhalt',
@@ -614,6 +619,7 @@ export const constrUnterhalt = new Layer({
       properties: {
         hasInfos: true,
         layerInfoComponent: 'ConstructionLayerInfo',
+        useOverlay: true,
         popupComponent: 'ConstructionPopup',
         construction: {
           art: 'Unterhalt',
@@ -631,6 +637,7 @@ export const constrUnterhalt = new Layer({
       properties: {
         hasInfos: true,
         layerInfoComponent: 'ConstructionLayerInfo',
+        useOverlay: true,
         popupComponent: 'ConstructionPopup',
         construction: {
           art: 'Unterhalt',
@@ -648,6 +655,7 @@ export const constrUnterhalt = new Layer({
       properties: {
         hasInfos: true,
         layerInfoComponent: 'ConstructionLayerInfo',
+        useOverlay: true,
         popupComponent: 'ConstructionPopup',
         construction: {
           art: 'Unterhalt',
@@ -753,6 +761,7 @@ export const constrClusters = new Layer({
       visible: true,
       mapboxLayer: constructionDataLayer,
       properties: {
+        useOverlay: true,
         popupComponent: 'ConstructionPopup',
       },
       styleLayer: {

--- a/src/config/layers.js
+++ b/src/config/layers.js
@@ -1470,6 +1470,7 @@ export const beleuchtungstaerken1Layer = new BeleuchtungsLayer({
   styleLayersFilter: ({ metadata }) => metadata && metadata.rte_klasse === '1',
   properties: {
     hasInfos: true,
+    useOverlay: true,
     popupComponent: 'BeleuchtungsPopup',
     layerInfoComponent: 'BeleuchtungLayerInfo',
   },
@@ -1481,6 +1482,7 @@ export const beleuchtungstaerken2aLayer = new BeleuchtungsLayer({
   styleLayersFilter: ({ metadata }) => metadata && metadata.rte_klasse === '2a',
   properties: {
     hasInfos: true,
+    useOverlay: true,
     popupComponent: 'BeleuchtungsPopup',
     layerInfoComponent: 'BeleuchtungLayerInfo',
   },
@@ -1492,6 +1494,7 @@ export const beleuchtungstaerken2bLayer = new BeleuchtungsLayer({
   styleLayersFilter: ({ metadata }) => metadata && metadata.rte_klasse === '2b',
   properties: {
     hasInfos: true,
+    useOverlay: true,
     popupComponent: 'BeleuchtungsPopup',
     layerInfoComponent: 'BeleuchtungLayerInfo',
   },
@@ -1503,6 +1506,7 @@ export const beleuchtungstaerken3Layer = new BeleuchtungsLayer({
   styleLayersFilter: ({ metadata }) => metadata && metadata.rte_klasse === '3',
   properties: {
     hasInfos: true,
+    useOverlay: true,
     popupComponent: 'BeleuchtungsPopup',
     layerInfoComponent: 'BeleuchtungLayerInfo',
   },
@@ -1514,6 +1518,7 @@ export const beleuchtungstaerken4Layer = new BeleuchtungsLayer({
   styleLayersFilter: ({ metadata }) => metadata && metadata.rte_klasse === '4',
   properties: {
     hasInfos: true,
+    useOverlay: true,
     popupComponent: 'BeleuchtungsPopup',
     layerInfoComponent: 'BeleuchtungLayerInfo',
   },
@@ -1556,6 +1561,7 @@ export const beleuchtungstaerkenSchutzgebieteLayer = new MapsGeoAdminLayer({
   ),
   properties: {
     featureInfoEventTypes: ['singleclick'],
+    useOverlay: true,
     popupComponent: 'MapsGeoAdminPopup',
   },
 });
@@ -1585,6 +1591,7 @@ export const beleuchtungstaerkenBundesInventareLayer = new MapsGeoAdminLayer({
   ),
   properties: {
     featureInfoEventTypes: ['singleclick'],
+    useOverlay: true,
     popupComponent: 'MapsGeoAdminPopup',
   },
 });

--- a/src/config/layers.js
+++ b/src/config/layers.js
@@ -1129,6 +1129,7 @@ export const zweitausbildungPois = new Layer({
       zIndex: 4,
       mapboxLayer: zweitausbildungPoisDataLayer,
       properties: {
+        useOverlay: true,
         popupComponent: 'ZweitausbildungPoisPopup',
         hasInfos: true,
         layerInfoComponent: 'ZweitausbildungSubLayerInfo',
@@ -1154,6 +1155,7 @@ export const zweitausbildungPois = new Layer({
       zIndex: 4,
       mapboxLayer: zweitausbildungPoisDataLayer,
       properties: {
+        useOverlay: true,
         popupComponent: 'ZweitausbildungPoisPopup',
         hasInfos: true,
         layerInfoComponent: 'ZweitausbildungSubLayerInfo',
@@ -1219,6 +1221,7 @@ export const zweitausbildungRoutes = new Layer({
           zIndex: 1,
           mapboxLayer: dataLayer,
           properties: {
+            useOverlay: true,
             popupComponent: 'ZweitausbildungRoutesPopup',
             zweitausbildung: {
               property: 'touristische_linie',
@@ -1258,6 +1261,7 @@ export const zweitausbildungRoutes = new Layer({
           zIndex: 1,
           mapboxLayer: dataLayer,
           properties: {
+            useOverlay: true,
             popupComponent: 'ZweitausbildungRoutesPopup',
             zweitausbildung: {
               property: 'hauptlinie',

--- a/src/config/layers.js
+++ b/src/config/layers.js
@@ -1289,6 +1289,7 @@ export const tarifverbundkarteLayer = new TarifverbundkarteLayer({
   visible: true,
   properties: {
     hideInLegend: true,
+    useOverlay: true,
     popupComponent: 'TarifverbundkartePopup',
   },
 });

--- a/src/popups/ZweitausbildungPoisPopup/ZweitausbildungPoisPopup.scss
+++ b/src/popups/ZweitausbildungPoisPopup/ZweitausbildungPoisPopup.scss
@@ -1,9 +1,7 @@
 .wkp-zweitausbildung-pois-popup {
   overflow-y: auto;
-  max-height: 300px;
 
   .wkp-zweitausbildung-pois-popup-row {
-    min-height: 50px;
     border-bottom: dashed 1px #bebebe;
     padding-top: 5px;
 
@@ -20,7 +18,7 @@
     padding: 6px;
 
     img {
-      max-width: 50%;
+      max-width: 100%;
     }
   }
 }

--- a/src/popups/ZweitausbildungRoutesPopup/ZweitausbildungRoutesPopup.scss
+++ b/src/popups/ZweitausbildungRoutesPopup/ZweitausbildungRoutesPopup.scss
@@ -1,7 +1,5 @@
 .wkp-zweitausbildung-routes-popup {
   overflow-y: auto;
-  max-height: 300px;
-  width: 420px;
 
   .wkp-zweitausbildung-routes-popup-row {
     min-height: 50px;


### PR DESCRIPTION
# How to

<!--  Please provide a test link and quick description how to see the change -->

All information displayed on click should be displayed in the right overlay, not the popup(except kilometrage layer)

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] The title means something for a human being.
- [x] The title contains [WIP] if it's necessary.
- [x] Labels applied. if it's a release? a hotfix?
- [x] Tests added.
