### PR TITLE
Add disableCookies and domainConsent properties

### DIFF
--- a/.env
+++ b/.env
@@ -13,4 +13,7 @@ REACT_APP_DRAW_URL=https://api.geops.io/drawings-public/v1/plan_editor/kml/
 REACT_APP_DRAW_OLD_URL=https://maps.trafimage.ch/services/cbs/trafzeich/kml/
 REACT_APP_DESTINATION_URL=//maps.trafimage.ch/search/v2/destinations
 REACT_APP_DEPARTURES_URL=//api.geops.io/sbb-departures/v1
-REACT_APP_DOMAIN_CONSENT_ID=784d5a56-cba1-4b22-9cde-019c2e67555a-test
+# Consent management
+REACT_APP_DOMAIN_CONSENT=trafimage.ch
+REACT_APP_DOMAIN_CONSENT_ID=230dafe6-f874-44f4-9e0a-0f5faf9bbed9
+

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "trafimage-maps",
   "description": "trafimage-maps web component",
-  "version": "1.7.22",
+  "version": "1.7.23-beta.2",
   "private": true,
   "main": "build/bundle.js",
   "proxy": "http://127.0.0.1:8000",

--- a/public/index.html
+++ b/public/index.html
@@ -163,6 +163,7 @@
         center="[810000, 5900000]"
         appName="wkp"
         activeTopicKey="ch.sbb.netzkarte"
+        domainConsent=".*"
       ></trafimage-maps>
       <!-- <div id="onetrust-consent-sdk">
         <div id="#onetrust-pc-sdk"></div>

--- a/src/WebComponent.js
+++ b/src/WebComponent.js
@@ -136,6 +136,11 @@ const propTypes = {
   enableTracking: PropTypes.string,
 
   /**
+   * Disable use of cookies when tracking is enabled and no domainConsentId is provided.
+   */
+  disableCookies: PropTypes.string,
+
+  /**
    * URL endpoint for matomo.
    */
   matomoUrl: PropTypes.string,
@@ -146,7 +151,14 @@ const propTypes = {
   matomoSiteId: PropTypes.string,
 
   /**
+   * Domain for which the domainConsentId is configured for.
+   */
+  domainConsent: PropTypes.string,
+
+  /**
    * OneTrust id used for consent Management.
+   * WARNING: OneTrust id can be domain dependent and with SameSite=LAX configured,
+   * so make sure OneTrust is properly configured for your domain.
    */
   domainConsentId: PropTypes.string,
 
@@ -179,9 +191,11 @@ const attributes = {
   shortenerUrl: process.env.REACT_APP_SHORTENER_URL,
   drawUrl: process.env.REACT_APP_DRAW_URL,
   enableTracking: 'true',
+  disableCookies: null,
   elements: undefined,
   layersVisibility: undefined,
   embedded: undefined,
+  domainConsent: process.env.REACT_APP_DOMAIN_CONSENT,
   domainConsentId: process.env.REACT_APP_DOMAIN_CONSENT_ID,
   matomoUrl: process.env.REACT_APP_MATOMO_URL_BASE,
   matomoSiteId: process.env.REACT_APP_MATOMO_SITE_ID,
@@ -214,7 +228,9 @@ const WebComponent = (props) => {
     elements,
     layersVisibility,
     embedded,
+    domainConsent,
     domainConsentId,
+    disableCookies,
   } = props;
 
   const arrayCenter = useMemo(() => {
@@ -340,6 +356,8 @@ const WebComponent = (props) => {
           center={arrayCenter}
           embedded={embedded === 'true'}
           enableTracking={enableTracking === 'true'}
+          disableCookies={disableCookies === 'true'}
+          domainConsent={domainConsent}
           domainConsentId={domainConsentId}
         />
       </div>

--- a/src/components/TrafimageMaps/TrafimageMaps.js
+++ b/src/components/TrafimageMaps/TrafimageMaps.js
@@ -292,14 +292,18 @@ class TrafimageMaps extends React.PureComponent {
       const isParentDomainAllowed =
         isIframe && allowedDomainRegex.test(window.parent.location.host);
       const isHttps = window.location.protocol === 'https:';
+
+      // Separate the logic avoid a warning if Secure=true and the site is http.
       const configurations =
         isIframe && isHttps
           ? {
-              // Chrome will use SameSite=LAX as fallback if the website use http, but we are not sure for other browsers.
+              // It's important that the OneTrust cookies also ahve the same properties,
+              // otherwise results of consent will never be saved
               setSecureCookie: true,
               setCookieSameSite: 'None',
             }
           : {
+              // Matomo set SameSite=LAX by default if nothing is provided.
               setCookieSameSite: 'LAX',
             };
       // console.log(window.OneTrust.GetDomainData());
@@ -319,8 +323,8 @@ class TrafimageMaps extends React.PureComponent {
       // - if the current domain is the same as the one configured by OneTrust for this domain consent id.
       // - if the web component is used in an iframe and the parent domain is also the one configured by OneTrust.
       // - if the web component is used in an iframe using https outside the OneTrust id domain,
-      //   in the case it uses http in an iframe Matomo cookies will use SameSite=LAX and will not add cookie to the page from
-      //   a 3rd party website, so no need a consent.
+      //   in the case it uses http in an iframe, Matomo cookies will use SameSite=LAX and will not add cookie to the page from
+      //   a 3rd party website, so no need of a consent.
       if (
         domainConsentId &&
         !disableCookies &&

--- a/src/components/TrafimageMaps/TrafimageMaps.test.js
+++ b/src/components/TrafimageMaps/TrafimageMaps.test.js
@@ -16,13 +16,16 @@ describe('TrafimageMaps', () => {
 
     test('enabled by default and active consent mechanism.', () => {
       const component = renderer.create(
-        <TrafimageMaps apiKey="" topics={[]} />,
+        <TrafimageMaps apiKey="" topics={[]} domainConsent=".*" />,
       );
       expect(createInstance).toHaveBeenCalledTimes(1);
       expect(createInstance).toHaveBeenCalledWith({
         siteId: '9',
         trackerUrl: 'https://analytics.geops.de/piwik.php',
         urlBase: 'https://analytics.geops.de/',
+        configurations: {
+          setCookieSameSite: 'LAX',
+        },
       });
       expect(component.getInstance().matomo).toBeDefined();
       expect(
@@ -40,7 +43,12 @@ describe('TrafimageMaps', () => {
 
       beforeEach(() => {
         const component = renderer.create(
-          <TrafimageMaps apiKey="" enableTracking topics={[]} />,
+          <TrafimageMaps
+            apiKey=""
+            enableTracking
+            topics={[]}
+            domainConsent=".*"
+          />,
         );
         store = component.getInstance().store;
         store.dispatch = jest.fn();

--- a/src/components/TrafimageMaps/TrafimageMaps.test.js
+++ b/src/components/TrafimageMaps/TrafimageMaps.test.js
@@ -5,6 +5,11 @@ import TrafimageMaps from '.';
 
 describe('TrafimageMaps', () => {
   describe('tracking and consent', () => {
+    afterEach(() => {
+      createInstance.mockClear();
+      window.OptanonWrapper = undefined;
+    });
+
     test('disabled', () => {
       const component = renderer.create(
         <TrafimageMaps apiKey="" enableTracking={false} topics={[]} />,
@@ -35,6 +40,37 @@ describe('TrafimageMaps', () => {
         component.getInstance().matomo.pushInstruction,
       ).toHaveBeenCalledWith('requireConsent');
       expect(window.OptanonWrapper).toBeDefined();
+    });
+
+    test('enabled by default and disable cookies without consent mechanism.', () => {
+      const component = renderer.create(
+        <TrafimageMaps
+          apiKey=""
+          topics={[]}
+          domainConsent=".*"
+          disableCookies
+        />,
+      );
+      expect(createInstance).toHaveBeenCalledTimes(1);
+      expect(createInstance).toHaveBeenCalledWith({
+        siteId: '9',
+        trackerUrl: 'https://analytics.geops.de/piwik.php',
+        urlBase: 'https://analytics.geops.de/',
+        configurations: {
+          setCookieSameSite: 'LAX',
+        },
+      });
+      expect(component.getInstance().matomo).toBeDefined();
+      const pushInstr = component.getInstance().matomo.pushInstruction;
+      expect(pushInstr).toHaveBeenCalledTimes(4);
+      expect(pushInstr).toHaveBeenCalledWith('disableCookies');
+      expect(pushInstr).toHaveBeenCalledWith(
+        'setCustomUrl',
+        'http://localhost/',
+      );
+      expect(pushInstr).toHaveBeenCalledWith('setDocumentTitle', '');
+      expect(pushInstr).toHaveBeenCalledWith('trackPageView');
+      expect(window.OptanonWrapper).toBeUndefined();
     });
 
     describe('OptanonWrapper callback .', () => {


### PR DESCRIPTION
# How to

<!--  Please provide a test link and quick description how to see the change -->

This PR displays consent banner only when it makes sense and use properly.

It display consent banner:

- if the current domain is the one allowed by OneTrust
- in a same domain iframe, only if the current domain AND the parent domain are the one allowed by OneTrust
- in 3rd party iframe using https, only if the current domain is the one allowed by OneTrust . 

OneTrust Cookies must be defined with SameSite=none and Secure=true

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] The title means something for a human being.
- [x] The title contains [WIP] if it's necessary.
- [x] Labels applied. if it's a release? a hotfix?
- [x] Tests added.
