### PR TITLE
fix(station-search): always show first Swiss station in search results when collapsed

### DIFF
--- a/src/searches/StopFinder/StopFinder.js
+++ b/src/searches/StopFinder/StopFinder.js
@@ -34,8 +34,26 @@ class StopFinder extends Search {
       });
   }
 
+  getItems() {
+    if (this.collapsed) {
+      // When collapsed we move first Swiss result to second position
+      const sorted = [...this.items];
+      console.log(sorted[0]);
+      const firstSwissStationIdx = sorted.findIndex(
+        (feat) => feat.properties.country_code === 'CH',
+      );
+      if (firstSwissStationIdx > 0) {
+        sorted.splice(1, 0, sorted.splice(firstSwissStationIdx, 1)[0]);
+      }
+      return sorted.slice(0, 2);
+    }
+    return this.items;
+  }
+
   render(item) {
-    return <div>{item.properties.name}</div>;
+    return (
+      <div>{`${item.properties.name} - ${item.properties.municipality_name} (${item.properties.country_code})`}</div>
+    );
   }
 
   // eslint-disable-next-line class-methods-use-this

--- a/src/searches/StopFinder/StopFinder.js
+++ b/src/searches/StopFinder/StopFinder.js
@@ -38,7 +38,6 @@ class StopFinder extends Search {
     if (this.collapsed) {
       // When collapsed we move first Swiss result to second position
       const sorted = [...this.items];
-      console.log(sorted[0]);
       const firstSwissStationIdx = sorted.findIndex(
         (feat) => feat.properties.country_code === 'CH',
       );


### PR DESCRIPTION
# How to
We always move the first Swiss search result (if there are any) to second position when the search resuslts are collapsed

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] The title means something for a human being and follows the [conventional commits](https://www.conventionalcommits.org/) specification.
- [x] The title contains [WIP] if it's necessary.
- [x] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
