### PR TITLE
Draft: Use base_bright_v2_legacy in Netzkarte Sandbox

### DIFF
--- a/src/config/ch.sbb.netzkarte.sandbox/index.js
+++ b/src/config/ch.sbb.netzkarte.sandbox/index.js
@@ -1,6 +1,19 @@
 import { Layer } from 'mobility-toolbox-js/ol';
+import TrafimageMapboxLayer from '../../layers/TrafimageMapboxLayer';
 import LevelLayer from '../../layers/LevelLayer';
-import { dataLayer, netzkarteLayer } from '../ch.sbb.netzkarte';
+import { netzkarteLayer } from '../ch.sbb.netzkarte';
+
+export const sandboxDataLayer = new TrafimageMapboxLayer({
+  name: 'ch.sbb.netzkarte.data',
+  visible: true,
+  isQueryable: false,
+  preserveDrawingBuffer: true,
+  zIndex: -1, // Add zIndex as the MapboxLayer would block tiled layers (buslines)
+  style: 'base_bright_v2_legacy',
+  properties: {
+    hideInLegend: true,
+  },
+});
 
 export const geschosseLayer = new Layer({
   name: 'ch.sbb.geschosse',
@@ -11,7 +24,7 @@ geschosseLayer.children = [-4, -3, -2, -1, 0, '2D', 1, 2, 3, 4].map((level) => {
   return new LevelLayer({
     name: `ch.sbb.geschosse${level}`,
     visible: level === '2D',
-    mapboxLayer: dataLayer,
+    mapboxLayer: sandboxDataLayer,
     isQueryable: false,
     styleLayersFilter: ({ metadata }) => metadata && metadata['geops.filter'],
     level,
@@ -22,4 +35,4 @@ geschosseLayer.children = [-4, -3, -2, -1, 0, '2D', 1, 2, 3, 4].map((level) => {
   });
 });
 
-export default [dataLayer, netzkarteLayer, geschosseLayer];
+export default [sandboxDataLayer, netzkarteLayer, geschosseLayer];


### PR DESCRIPTION
# How to
Currently Netzkarte Sandbox uses _base_bright_v2_ch.sbb.netzkarte_, loading a lot of data the topic doesn't need (e.g. Direktverbindungen). Instead, we could use the base style base_bright_v2 or create a new topic-specific partial.

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [ ] It's not a hack or at least an unauthorized hack :).
- [ ] The images added are optimized.
- [ ] Everything in ticket description has been fixed.
- [ ] The author of the MR has made its own review before assigning the reviewer.
- [ ] The title means something for a human being and follows the [conventional commits](https://www.conventionalcommits.org/) specification.
- [ ] The title contains [WIP] if it's necessary.
- [ ] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
