### PR TITLE
fix: only return one platform at a time

### DIFF
--- a/src/layers/PlatformsLayer/PlatformsLayer.js
+++ b/src/layers/PlatformsLayer/PlatformsLayer.js
@@ -207,6 +207,20 @@ class PlatformsLayer extends MapboxStyleLayer {
       });
     }
   }
+
+  getFeatureInfoAtCoordinate(coordinate, options) {
+    return super
+      .getFeatureInfoAtCoordinate(coordinate, options)
+      .then((featureInfo) => {
+        // We want only one platform selected at a time, to avoid having duplication of data in the popup
+        return {
+          ...featureInfo,
+          features: featureInfo.features.length
+            ? [featureInfo.features[0]]
+            : [],
+        };
+      });
+  }
 }
 
 export default PlatformsLayer;

--- a/src/layers/PlatformsLayer/PlatformsLayer.test.js
+++ b/src/layers/PlatformsLayer/PlatformsLayer.test.js
@@ -1,0 +1,20 @@
+import { MapboxStyleLayer } from 'mobility-toolbox-js/ol';
+import PlatformsLayer from './PlatformsLayer';
+
+describe('PlatformsLayer', () => {
+  test('return only one featureInfo to avoid duplicate data in der Popup [TRAFDATA-334]', (done) => {
+    const feat1 = { id: 'feat1' };
+    const feat2 = { id: 'feat2' };
+    MapboxStyleLayer.prototype.getFeatureInfoAtCoordinate = jest.fn(() =>
+      Promise.resolve({
+        features: [feat1, feat2],
+      }),
+    );
+    const layer = new PlatformsLayer();
+    layer.getFeatureInfoAtCoordinate().then((featureInfo) => {
+      expect(featureInfo.features.length).toBe(1);
+      expect(featureInfo.features[0]).toBe(feat1);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
# How to

<!--  Please provide a test link and quick description how to see the change -->

When clicking on 2 platforms at a time, some data in the popup were duplicated. So with this PR we only allow one platform to be selected,

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] The title means something for a human being and follows the [conventional commits](https://www.conventionalcommits.org/) specification.
- [x] The title contains [WIP] if it's necessary.
- [x] Labels applied. if it's a release? a hotfix?
- [x] Tests added.
