### PR TITLE
fix(Regionenkarte Public): prevent permalink parameters from using private roles in popup

### DIFF
--- a/.github/workflows/cypress-chrome.yml
+++ b/.github/workflows/cypress-chrome.yml
@@ -10,7 +10,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Cypress install
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v5
         with:
           runTests: false
       # report machine parameters

--- a/.github/workflows/cypress-chrome.yml
+++ b/.github/workflows/cypress-chrome.yml
@@ -10,7 +10,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Cypress install
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@v4
         with:
           runTests: false
       # report machine parameters

--- a/src/popups/RegionenkarteSegmentPopup/Av.js
+++ b/src/popups/RegionenkarteSegmentPopup/Av.js
@@ -42,7 +42,9 @@ function Av({ layer, feature, onChangeRole }) {
   const parsed = qs.parseUrl(window.location.href);
   const permalinkParam = parsed.query[PERMALINK_PARAM];
   const [role, setRole] = useState(
-    (roles.includes(permalinkParam) && permalinkParam) || roles[0],
+    isIntern
+      ? (roles.includes(permalinkParam) && permalinkParam) || roles[0]
+      : 'av_bnb',
   );
   const [person, setPerson] = useState();
   const [lineData, setLineData] = useState();

--- a/src/popups/RegionenkarteSegmentPopup/Person.js
+++ b/src/popups/RegionenkarteSegmentPopup/Person.js
@@ -24,7 +24,7 @@ function Person({ isIntern, person }) {
       name={name}
       division={division}
       phone={formatPhone(phone)}
-      email={isIntern && email}
+      email={isIntern ? email : undefined}
       className={classes.personCard}
     />
   ) : (


### PR DESCRIPTION
# How to

Currently changing the AV role in the private _Analgenverantwortliche_ topic causes popup in the public _Koordinatoren Bahnnahes Bauen_ topic to also use that role instead of av_bnb. It is triggered because of the permalink parameter _anlagegattung_.

Fix:
- Ignore permalink parameter when in public topic

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [ ] It's not a hack or at least an unauthorized hack :).
- [ ] The images added are optimized.
- [ ] Everything in ticket description has been fixed.
- [ ] The author of the MR has made its own review before assigning the reviewer.
- [ ] The title means something for a human being and follows the [conventional commits](https://www.conventionalcommits.org/) specification.
- [ ] The title contains [WIP] if it's necessary.
- [ ] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
