### PR TITLE
fix(Anlagenverantwortliche): remove map update on language switch (fixes the AV popup dropdown)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "trafimage-maps",
   "description": "trafimage-maps web component",
-  "version": "1.19.4-beta.1",
+  "version": "1.19.4-beta.2",
   "private": true,
   "main": "build/bundle.js",
   "proxy": "http://127.0.0.1:8000",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "trafimage-maps",
   "description": "trafimage-maps web component",
-  "version": "1.19.4-beta.0",
+  "version": "1.19.4-beta.1",
   "private": true,
   "main": "build/bundle.js",
   "proxy": "http://127.0.0.1:8000",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "trafimage-maps",
   "description": "trafimage-maps web component",
-  "version": "1.19.3",
+  "version": "1.19.4-beta.0",
   "private": true,
   "main": "build/bundle.js",
   "proxy": "http://127.0.0.1:8000",

--- a/src/components/LanguageSelect/LanguageSelect.js
+++ b/src/components/LanguageSelect/LanguageSelect.js
@@ -72,7 +72,11 @@ const LanguageSelect = () => {
   const langOptions = useMemo(() => {
     return options.map((opt) => {
       return (
-        <MenuItem key={opt.value} value={opt.value}>
+        <MenuItem
+          key={opt.value}
+          value={opt.value}
+          data-cy={`lang-select-option-${opt.value}`}
+        >
           {opt.label}
         </MenuItem>
       );

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -61,6 +61,7 @@ const Select = (props) => {
     <MuiSelect
       variant="outlined"
       IconComponent={ExpandMoreIcon}
+      data-testid="trafimage-maps-select"
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...props}
       // The following props need to be set after {...newProps}, since they overwrite some of them

--- a/src/components/TopicLoader/TopicLoader.js
+++ b/src/components/TopicLoader/TopicLoader.js
@@ -95,7 +95,6 @@ class TopicLoader extends PureComponent {
   componentDidUpdate(prevProps) {
     const {
       activeTopic,
-      language,
       topics,
       permissionInfos,
       apiKey,
@@ -130,7 +129,6 @@ class TopicLoader extends PureComponent {
     } else if (
       activeTopic &&
       (apiKey !== prevProps.apiKey ||
-        language !== prevProps.language ||
         apiKeyName !== prevProps.apiKeyName ||
         appBaseUrl !== prevProps.appBaseUrl ||
         cartaroUrl !== prevProps.cartaroUrl ||

--- a/src/popups/RegionenkarteSegmentPopup/Av.js
+++ b/src/popups/RegionenkarteSegmentPopup/Av.js
@@ -111,7 +111,7 @@ function Av({ layer, feature, onChangeRole }) {
         ref={(el) => setFullWidth(el?.clientWidth)}
       >
         <div>
-          {!isIntern && (
+          {isIntern && (
             <Select
               value={role}
               onChange={(evt) => setRole(evt.target.value)}

--- a/src/popups/RegionenkarteSegmentPopup/Av.js
+++ b/src/popups/RegionenkarteSegmentPopup/Av.js
@@ -19,7 +19,7 @@ const useStyles = makeStyles((theme) => ({
     },
   },
   menuItem: {
-    width: (props) => props.fullWidth - 4,
+    width: (props) => props.selectWidth - 4,
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
     display: 'block',
@@ -53,8 +53,8 @@ function Av({ layer, feature, onChangeRole }) {
   );
   const [person, setPerson] = useState();
   const [lineData, setLineData] = useState();
-  const [fullWidth, setFullWidth] = useState();
-  const classes = useStyles({ fullWidth });
+  const [selectWidth, setSelectWidth] = useState();
+  const classes = useStyles({ selectWidth });
 
   useEffect(() => {
     const abortController = new AbortController();
@@ -108,7 +108,7 @@ function Av({ layer, feature, onChangeRole }) {
       <Line feature={feature} />
       <div
         className={classes.description}
-        ref={(el) => setFullWidth(el?.clientWidth)}
+        ref={(el) => setSelectWidth(el?.clientWidth)}
       >
         <div>
           {isIntern && (

--- a/src/popups/RegionenkarteSegmentPopup/Av.js
+++ b/src/popups/RegionenkarteSegmentPopup/Av.js
@@ -111,12 +111,13 @@ function Av({ layer, feature, onChangeRole }) {
         ref={(el) => setFullWidth(el?.clientWidth)}
       >
         <div>
-          {isIntern && (
+          {!isIntern && (
             <Select
               value={role}
               onChange={(evt) => setRole(evt.target.value)}
               fullWidth
               MenuProps={{ marginThreshold: 0 }}
+              data-cy="av-role-select"
             >
               {[...roles]
                 .sort((a, b) => (t(a) < t(b) ? -1 : 1))
@@ -127,6 +128,7 @@ function Av({ layer, feature, onChangeRole }) {
                       value={value}
                       className={classes.menuItem}
                       title={t(value)}
+                      data-cy={`av-role-option-${value}`}
                     >
                       {t(value)}
                     </MenuItem>

--- a/src/popups/RegionenkarteSegmentPopup/Av.js
+++ b/src/popups/RegionenkarteSegmentPopup/Av.js
@@ -18,6 +18,12 @@ const useStyles = makeStyles((theme) => ({
       paddingBottom: theme.spacing(2),
     },
   },
+  menuItem: {
+    width: (props) => props.fullWidth - 4,
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    display: 'block',
+  },
 }));
 
 const roles = [
@@ -35,7 +41,6 @@ const PERMALINK_PARAM = 'anlagegattung';
 
 function Av({ layer, feature, onChangeRole }) {
   const { t } = useTranslation();
-  const classes = useStyles();
   const cartaroUrl = useSelector((state) => state.app.cartaroUrl);
   const accessType = layer.get('accessType') || 'public';
   const isIntern = accessType === 'intern';
@@ -48,6 +53,8 @@ function Av({ layer, feature, onChangeRole }) {
   );
   const [person, setPerson] = useState();
   const [lineData, setLineData] = useState();
+  const [fullWidth, setFullWidth] = useState();
+  const classes = useStyles({ fullWidth });
 
   useEffect(() => {
     const abortController = new AbortController();
@@ -99,19 +106,28 @@ function Av({ layer, feature, onChangeRole }) {
   return (
     <>
       <Line feature={feature} />
-      <div className={classes.description}>
+      <div
+        className={classes.description}
+        ref={(el) => setFullWidth(el?.clientWidth)}
+      >
         <div>
           {isIntern && (
             <Select
               value={role}
               onChange={(evt) => setRole(evt.target.value)}
               fullWidth
+              MenuProps={{ marginThreshold: 0 }}
             >
               {[...roles]
                 .sort((a, b) => (t(a) < t(b) ? -1 : 1))
                 .map((value) => {
                   return (
-                    <MenuItem key={value} value={value}>
+                    <MenuItem
+                      key={value}
+                      value={value}
+                      className={classes.menuItem}
+                      title={t(value)}
+                    >
                       {t(value)}
                     </MenuItem>
                   );


### PR DESCRIPTION
# How to
Since we update the map on language change the AV popup loses the reference to the AV layer and crashes.
Fix:
- remove the map update on language switch, fixes the popup behaviour
- improve the CSS for the AV dropdown options, prevent it form inflating over the input width 
- add data attributes for cypress tests in gitlab

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] The title means something for a human being and follows the [conventional commits](https://www.conventionalcommits.org/) specification.
- [x] The title contains [WIP] if it's necessary.
- [x] Labels applied. if it's a release? a hotfix?
- [x] Tests added.
