### PR TITLE
fix: add more space when sbb switch are on the same row

### DIFF
--- a/src/menus/DirektverbindungenMenu/DvLayerSwitcher.js
+++ b/src/menus/DirektverbindungenMenu/DvLayerSwitcher.js
@@ -13,6 +13,9 @@ import DvLegendLine from '../../config/ch.sbb.direktverbindungen/DvLegendLine/Dv
 const useStyles = makeStyles(() => {
   return {
     switchWrapper: {
+      '& label:first-child': {
+        marginRight: 30,
+      },
       '& .MuiFormControlLabel-label': {
         fontSize: 16,
       },


### PR DESCRIPTION
# How to

<!--  Please provide a test link and quick description how to see the change -->

open direktverbnindungen iframe topic -> reduce the width of the window to 485

Before:
![image](https://github.com/geops/trafimage-maps/assets/621420/38bb0966-7378-4974-b29c-c21d8c136fd3)


After:
![image](https://github.com/geops/trafimage-maps/assets/621420/75e2aa33-bec8-443b-a2ef-a2779354430d)


# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [ ] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] The title means something for a human being and follows the [conventional commits](https://www.conventionalcommits.org/) specification.
- [x] The title contains [WIP] if it's necessary.
- [x] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
