### PR TITLE
fix: add transition when the overlay snap

### DIFF
--- a/src/components/Overlay/Overlay.js
+++ b/src/components/Overlay/Overlay.js
@@ -65,6 +65,9 @@ const useStyles = makeStyles((theme) => ({
     '& .wkp-feature-information': {
       width: '100%',
     },
+    '& > .MuiPaper-root > div:first-child': {
+      transition: 'height .3s ease',
+    },
   },
   drawerMobilePaper: {
     position: 'absolute',

--- a/src/components/Overlay/Overlay.js
+++ b/src/components/Overlay/Overlay.js
@@ -1,4 +1,10 @@
-import React, { useMemo, useRef, useCallback, useEffect } from 'react';
+import React, {
+  useMemo,
+  useRef,
+  useCallback,
+  useEffect,
+  useState,
+} from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import { makeStyles, Drawer } from '@material-ui/core';
@@ -150,6 +156,7 @@ const Overlay = ({
   const classes = useStyles();
   const screenWidth = useSelector((state) => state.app.screenWidth);
   const resizeRef = useRef(null);
+  const [isSnapSmooth, setSnapSmooth] = useState(false);
   const { defaultSize } = ResizableProps;
 
   const isMobile = useMemo(() => {
@@ -201,15 +208,13 @@ const Overlay = ({
   if (!children && !filtered.length) {
     return null;
   }
-  console.log(ResizableProps.snap);
-
   return (
     <div>
       <Drawer
         transitionDuration={transitionDuration}
         className={`${classes.drawer} ${
           isMobile ? classes.drawerMobile : classes.drawerDesktop
-        } ${ResizableProps.snap ? classes.drawerMobileSmooth : ''}`}
+        } ${isSnapSmooth ? classes.drawerMobileSmooth : ''}`}
         classes={{
           root: classes.drawerRoot,
           paper: isMobile
@@ -244,20 +249,17 @@ const Overlay = ({
             maxHeight="100vh"
             minHeight={OVERLAY_MIN_HEIGHT}
             onResizeStart={() => {
-              console.log('resiestart');
-            }}
-            onResizeStop={(evt, direction, ref, delta) => {
-              // We do the sanp manually to have a better effect
-              const snaps = ResizableProps?.snap?.y;
-              console.log('resiestop', delta, ref, snaps);
               if (ResizableProps?.snap?.y) {
+                setSnapSmooth(false);
+              }
+            }}
+            onResizeStop={() => {
+              // We do the snap manually to have a befalsetance = Infinity;
+              const snaps = ResizableProps?.snap?.y;
+              if (snaps) {
                 let closerSnapDistance = Infinity;
                 let closerSnap = snaps[0];
                 snaps.forEach((snap) => {
-                  console.log(
-                    'resiestop',
-                    resizeRef.current.state.height - snap,
-                  );
                   if (
                     Math.abs(resizeRef.current.state.height - snap) <
                     closerSnapDistance
@@ -266,18 +268,8 @@ const Overlay = ({
                     closerSnap = snap;
                   }
                 });
-                console.log('closerSnap', closerSnap);
+                setSnapSmooth(true);
                 resizeRef.current.updateSize({ height: closerSnap });
-              }
-            }}
-            onResize={(evt) => {
-              if (evt.touches[0]) {
-                resizeRef.current.updateSize({
-                  height:
-                    document.documentElement.clientHeight -
-                    evt.touches[0].clientY,
-                });
-                console.log('resies', resizeRef.current);
               }
             }}
             handleComponent={{
@@ -297,6 +289,7 @@ const Overlay = ({
             }}
             // eslint-disable-next-line react/jsx-props-no-spreading
             {...ResizableProps}
+            snap={null} // We do the snap manually
           >
             {children || <FeatureInformation featureInfo={filtered} />}
           </Resizable>

--- a/src/components/Overlay/Overlay.js
+++ b/src/components/Overlay/Overlay.js
@@ -65,6 +65,8 @@ const useStyles = makeStyles((theme) => ({
     '& .wkp-feature-information': {
       width: '100%',
     },
+  },
+  drawerMobileSmooth: {
     '& > .MuiPaper-root > div:first-child': {
       transition: 'height .3s ease',
     },
@@ -199,6 +201,7 @@ const Overlay = ({
   if (!children && !filtered.length) {
     return null;
   }
+  console.log(ResizableProps.snap);
 
   return (
     <div>
@@ -206,7 +209,7 @@ const Overlay = ({
         transitionDuration={transitionDuration}
         className={`${classes.drawer} ${
           isMobile ? classes.drawerMobile : classes.drawerDesktop
-        }`}
+        } ${ResizableProps.snap ? classes.drawerMobileSmooth : ''}`}
         classes={{
           root: classes.drawerRoot,
           paper: isMobile
@@ -240,6 +243,43 @@ const Overlay = ({
             enable={{ top: isMobile }}
             maxHeight="100vh"
             minHeight={OVERLAY_MIN_HEIGHT}
+            onResizeStart={() => {
+              console.log('resiestart');
+            }}
+            onResizeStop={(evt, direction, ref, delta) => {
+              // We do the sanp manually to have a better effect
+              const snaps = ResizableProps?.snap?.y;
+              console.log('resiestop', delta, ref, snaps);
+              if (ResizableProps?.snap?.y) {
+                let closerSnapDistance = Infinity;
+                let closerSnap = snaps[0];
+                snaps.forEach((snap) => {
+                  console.log(
+                    'resiestop',
+                    resizeRef.current.state.height - snap,
+                  );
+                  if (
+                    Math.abs(resizeRef.current.state.height - snap) <
+                    closerSnapDistance
+                  ) {
+                    closerSnapDistance = resizeRef.current.state.height - snap;
+                    closerSnap = snap;
+                  }
+                });
+                console.log('closerSnap', closerSnap);
+                resizeRef.current.updateSize({ height: closerSnap });
+              }
+            }}
+            onResize={(evt) => {
+              if (evt.touches[0]) {
+                resizeRef.current.updateSize({
+                  height:
+                    document.documentElement.clientHeight -
+                    evt.touches[0].clientY,
+                });
+                console.log('resies', resizeRef.current);
+              }
+            }}
             handleComponent={{
               top: (
                 <>

--- a/src/menus/DirektverbindungenMenu/DvLayerSwitcher.js
+++ b/src/menus/DirektverbindungenMenu/DvLayerSwitcher.js
@@ -14,7 +14,7 @@ const useStyles = makeStyles(() => {
   return {
     switchWrapper: {
       '& label:first-child': {
-        marginRight: 30,
+        marginRight: 20,
       },
       '& .MuiFormControlLabel-label': {
         fontSize: 16,


### PR DESCRIPTION
# How to

<!--  Please provide a test link and quick description how to see the change -->
Open ch.sbb.direktverbindungen-iframe topic -> reduce the size of the window to mobile -> select a line -> scroll the overlay.

Now the overlay follow the cursor then snap smoothly to the cloest snap breakpoint defined.

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] The title means something for a human being and follows the [conventional commits](https://www.conventionalcommits.org/) specification.
- [x] The title contains [WIP] if it's necessary.
- [x] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
