### PR TITLE
fix(Netzkarte Sandbox): clone Netzkarte layers in sandbox topic to prevent residuals on topic switch

### DIFF
--- a/src/config/ch.sbb.netzkarte.sandbox/index.js
+++ b/src/config/ch.sbb.netzkarte.sandbox/index.js
@@ -4,6 +4,13 @@ import LevelLayer from '../../layers/LevelLayer';
 import { dataLayer, netzkarteLayer } from '../ch.sbb.netzkarte';
 import netzkarte from '../../img/netzkarte.png';
 
+const sandboxDataLayer = dataLayer.clone({
+  key: 'ch.sbb.netzkarte.sandbox.data',
+});
+const sandboxNetzkarteLayer = netzkarteLayer.clone({
+  key: 'ch.sbb.netzkarte.sandbox',
+  mapboxLayer: sandboxDataLayer,
+});
 export const poiLayer = new MapboxStyleLayer({
   name: 'ROKAS-POIs',
   key: 'ch.sbb.poi',
@@ -13,7 +20,7 @@ export const poiLayer = new MapboxStyleLayer({
     isBaseLayer: true,
   },
   visible: false,
-  mapboxLayer: dataLayer,
+  mapboxLayer: sandboxDataLayer,
   styleLayersFilter: ({ metadata }) =>
     !!metadata && metadata['trafimage.filter'] === 'perimeter_mask',
   style: 'base_bright_v2_poi',
@@ -28,7 +35,7 @@ geschosseLayer.children = [-4, -3, -2, -1, 0, '2D', 1, 2, 3, 4].map((level) => {
   return new LevelLayer({
     name: `ch.sbb.geschosse${level}`,
     visible: level === '2D',
-    mapboxLayer: dataLayer,
+    mapboxLayer: sandboxDataLayer,
     styleLayersFilter: ({ metadata }) => metadata && metadata['geops.filter'],
     level,
     group: 'ch.sbb.geschosse-layer',
@@ -38,4 +45,9 @@ geschosseLayer.children = [-4, -3, -2, -1, 0, '2D', 1, 2, 3, 4].map((level) => {
   });
 });
 
-export default [dataLayer, netzkarteLayer, poiLayer, geschosseLayer];
+export default [
+  sandboxDataLayer,
+  sandboxNetzkarteLayer,
+  poiLayer,
+  geschosseLayer,
+];


### PR DESCRIPTION
# How to
When switching to ROKAS-POIs baselayer in the Netzkarte-Sandbox topic, then switching to Netzkarte topic, the POI layer remains visible in mapbox, because both topics use the same layer instances.

Fix: Clone the layers from Netzkarte topic

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [ ] It's not a hack or at least an unauthorized hack :).
- [ ] The images added are optimized.
- [ ] Everything in ticket description has been fixed.
- [ ] The author of the MR has made its own review before assigning the reviewer.
- [ ] The title means something for a human being and follows the [conventional commits](https://www.conventionalcommits.org/) specification.
- [ ] The title contains [WIP] if it's necessary.
- [ ] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
