### PR TITLE
fix(punctuality): redefine stylelayersFilter for regional trains in tracker

### DIFF
--- a/src/config/ch.sbb.netzkarte/index.js
+++ b/src/config/ch.sbb.netzkarte/index.js
@@ -226,9 +226,7 @@ if (!punctuality.permalinkFilter) {
       properties: {
         filter: ({ properties }) => {
           const { type, line } = properties;
-          return (
-            type === 'rail' && /^(S|R$|RE|PE|D|IRE|RB|TER)/.test(line?.name)
-          );
+          return type === 'rail' && !/(IR|IC|EC|RJX|TGV)/.test(line?.name);
         },
       },
     }),


### PR DESCRIPTION
# How to
Changed stylelayersFilter in Nahverkehr-Layers in punctuality to be any rail features that are not Fernverkehr.

# Others

- [ ] It's not a hack or at least an unauthorized hack :).
- [ ] The images added are optimized.
- [ ] Everything in ticket description has been fixed.
- [ ] The author of the MR has made its own review before assigning the reviewer.
- [ ] The title means something for a human being and follows the [conventional commits](https://www.conventionalcommits.org/) specification.
- [ ] The title contains [WIP] if it's necessary.
- [ ] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
