### PR TITLE
fix(STS): ensure hidden layers visibility is applied after switch from STS DV to STS validity

### DIFF
--- a/src/config/ch.sbb.sts/index.js
+++ b/src/config/ch.sbb.sts/index.js
@@ -16,6 +16,7 @@ const FILTER_LINE_VALUE = 'sts.line'; // style using nova daten
 const STS_DATA_LAYER_KEY = 'ch.sbb.sts.data';
 const HIGHLIGHTS_LAYER_KEY = 'ch.sbb.sts.validity.highlights';
 const ROUTES_HIGHLIGHT_LAYER_KEY = 'ch.sbb.sts.validity.routes_highlight';
+const STS_HIDDEN_ROUTES_LAYER_KEY = 'ch.sbb.sts.validity.hidden';
 const OTHER_LAYER_KEY = 'ch.sbb.sts.validity.other';
 const GTTOS_LAYER_KEY = 'ch.sbb.sts.validity.gttos';
 const PREMIUM_LAYER_KEY = 'ch.sbb.sts.validity.premium';
@@ -65,6 +66,7 @@ export const highlightRoutes = new HighlightRoutesLayer({
 // Hide the routes displayed by default like gqa ones
 const hiddenRoutes = new MapboxStyleLayer({
   name: 'Hidden routes',
+  key: STS_HIDDEN_ROUTES_LAYER_KEY,
   mapboxLayer: stsDataLayer,
   visible: false,
   styleLayersFilter: ({ metadata, id }) =>

--- a/src/menus/StsMenu/StsMenu.js
+++ b/src/menus/StsMenu/StsMenu.js
@@ -69,9 +69,13 @@ const updateLayers = (key = 'sts', baseLayer) => {
   if (key === 'sts') {
     stsLayers.forEach((layer) => {
       layer.visible =
-        /(ch\.sbb\.sts\.validity(?!\.(highlights|premium)$)|\.data$)/.test(
+        /(ch\.sbb\.sts\.validity(?!\.(highlights|premium|hidden)$)|\.data$)/.test(
           layer.key,
         );
+      // Ensure layout visibility is applied after style url change (otherwise hidden layers will be displayed)
+      if (layer.applyLayoutVisibility) {
+        layer.applyLayoutVisibility();
+      }
     });
   }
   if (key === 'dv') {


### PR DESCRIPTION
# How to

When switching back to STS validity from STS DV, the hidden layers (e.g. the white line background) layout visibility needs to be reapplied

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [ ] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] The title means something for a human being and follows the [conventional commits](https://www.conventionalcommits.org/) specification.
- [x] The title contains [WIP] if it's necessary.
- [x] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
