### PR TITLE
fix(NetzkartePopup): ensure the Abfahrtstafel is displayed on all zoom levels for bus stations

### DIFF
--- a/src/popups/DeparturePopup/DeparturePopup.js
+++ b/src/popups/DeparturePopup/DeparturePopup.js
@@ -5,11 +5,10 @@ import { withTranslation } from "react-i18next";
 import DeparturePopupContent from "./DeparturePopupContent";
 
 function DeparturePopup({ feature, children }) {
-  const platform = feature.get("platform");
-  const uic = parseFloat(feature.get("sbb_id"));
+  const { platform, uic_ref: uicRef, sbb_id: sbbId } = feature.getProperties();
 
   return (
-    <DeparturePopupContent uic={uic} platform={platform} showTitle>
+    <DeparturePopupContent uic={sbbId || uicRef} platform={platform} showTitle>
       {children}
     </DeparturePopupContent>
   );

--- a/src/popups/NetzkartePopup/NetzkartePopup.js
+++ b/src/popups/NetzkartePopup/NetzkartePopup.js
@@ -32,6 +32,7 @@ function NetzkartePopup({ feature, coordinate }) {
     longitude,
     altitude,
     sbb_id: sbbId,
+    uic_ref: uicRef,
     layer,
     rail,
     ferry,
@@ -61,10 +62,11 @@ function NetzkartePopup({ feature, coordinate }) {
   // (it should be > -1).
   const isAirport = styleLayer && styleLayer.indexOf("flug") > 0;
 
-  const floatSbbId = parseFloat(sbbId);
+  const finalSbbId = sbbId || uicRef;
+  const floatSbbId = parseFloat(finalSbbId);
   const didok =
     (countryCode && countryCode === "CH") ||
-    (!countryCode && floatSbbId >= 8500000 && /^85/.test(sbbId))
+    (!countryCode && floatSbbId >= 8500000 && /^85/.test(finalSbbId))
       ? floatSbbId - 8500000
       : null;
 


### PR DESCRIPTION
# How to
Bus stations on zoom level > 14 currently have no Abfahrtstafel Link in the Popup, because the station data Attribute for containing the DIDOK number is called _uic/_ref_ instead of _sbb/_id_.

The frontend was adapted to consider uic_ref as well

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [ ] It's not a hack or at least an unauthorized hack :).
- [ ] The images added are optimized.
- [ ] Everything in ticket description has been fixed.
- [ ] The author of the MR has made its own review before assigning the reviewer.
- [ ] The title means something for a human being and follows the [conventional commits](https://www.conventionalcommits.org/) specification.
- [ ] The title contains [WIP] if it's necessary.
- [ ] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
