### PR TITLE
fix(Haltekanten): remove stop_positions from StationsLayer, use metadata tag in PlatformsLayer

### DIFF
--- a/src/layers/PlatformsLayer/PlatformsLayer.js
+++ b/src/layers/PlatformsLayer/PlatformsLayer.js
@@ -116,9 +116,12 @@ class PlatformsLayer extends MapboxStyleLayer {
    */
   onLoad() {
     const { mbMap } = this.mapboxLayer;
-    this.platformLayers = mbMap.getStyle().layers.filter((layer) => {
-      return layer.type === "symbol" && layer["source-layer"] === "platform";
-    });
+    this.platformLayers = mbMap
+      .getStyle()
+      .layers.filter(
+        ({ metadata }) =>
+          metadata && /^stop_position/.test(metadata["general.filter"]),
+      );
 
     this.platformLayers = this.platformLayers.map((layer) => layer.id);
 

--- a/src/layers/StationsLayer/StationsLayer.js
+++ b/src/layers/StationsLayer/StationsLayer.js
@@ -67,8 +67,7 @@ class StationsLayer extends MapboxStyleLayer {
       .getStyle()
       .layers.filter(
         ({ metadata }) =>
-          metadata &&
-          /^(stations|stop_position)/.test(metadata["general.filter"]),
+          metadata && /^stations/.test(metadata["general.filter"]),
       )
       .map((layer) => layer.id);
 


### PR DESCRIPTION
# How to
Currently the platforms select two features on click, resulting in duplicate popup content in the NetzkartePopup.
Also some polygon nodes are added to the highlighting, which should not be displayed
Both Bugs result from adding the stop_position regex to the StationLayer, so the platforms are selected in StationLayer and in PlatformsLayer

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [ ] It's not a hack or at least an unauthorized hack :).
- [ ] The images added are optimized.
- [ ] Everything in ticket description has been fixed.
- [ ] The author of the MR has made its own review before assigning the reviewer.
- [ ] The title means something for a human being and follows the [conventional commits](https://www.conventionalcommits.org/) specification.
- [ ] The title contains [WIP] if it's necessary.
- [ ] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
