### PR TITLE
fix(overlay): remove features from overlay when deactivating layers

### DIFF
--- a/src/components/FeatureInformation/FeatureInformation.js
+++ b/src/components/FeatureInformation/FeatureInformation.js
@@ -1,40 +1,17 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import PropTypes from "prop-types";
 import { useTranslation } from "react-i18next";
 import { MdClose } from "react-icons/md";
 import { IoIosArrowRoundBack, IoIosArrowRoundForward } from "react-icons/io";
 import { Link, IconButton } from "@mui/material";
-import { unByKey } from "ol/Observable";
 import { setFeatureInfo } from "../../model/app/actions";
+import useUpdateFeatureInfoOnLayerToggle from "../../utils/useUpdateFeatureInfoOnLayerToggle";
 import useIndexedFeatureInfo from "../../utils/useIndexedFeatureInfo";
 import useHighlightLayer from "../../utils/useHighlightLayer";
 import getPopupComponent from "../../utils/getPopupComponent";
 import "./FeatureInformation.scss";
-
-const useUpdateFeatureInfoOnLayerDeactivate = (layers, featureInfo) => {
-  const dispatch = useDispatch();
-  useEffect(() => {
-    const listeners = [];
-    layers.forEach((l) => {
-      const listener = l?.on("change:visible", (evt) => {
-        const layer = evt.target;
-        if (!layer.visible) {
-          layer.select();
-          layer.highlight();
-          dispatch(
-            setFeatureInfo(featureInfo.filter((info) => info.layer !== layer)),
-          );
-        }
-      });
-      listeners.push(listener);
-    });
-    return () => {
-      unByKey(listeners);
-    };
-  }, [layers, featureInfo, dispatch]);
-};
 
 function FeatureInformation({ featureInfo }) {
   const { t } = useTranslation();
@@ -52,7 +29,7 @@ function FeatureInformation({ featureInfo }) {
   useHighlightLayer(featureInfo, highlightLayer, featureIndex);
 
   // Hook to filter out selected features for deactivated layers
-  useUpdateFeatureInfoOnLayerDeactivate(infoIndexed.layers.flat(), featureInfo);
+  useUpdateFeatureInfoOnLayerToggle(infoIndexed.layers.flat(), featureInfo);
 
   // The current feature(s) to display.
   const feature = infoIndexed.features[featureIndex];

--- a/src/components/FeatureInformation/FeatureInformation.js
+++ b/src/components/FeatureInformation/FeatureInformation.js
@@ -1,16 +1,40 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import PropTypes from "prop-types";
 import { useTranslation } from "react-i18next";
 import { MdClose } from "react-icons/md";
 import { IoIosArrowRoundBack, IoIosArrowRoundForward } from "react-icons/io";
 import { Link, IconButton } from "@mui/material";
+import { unByKey } from "ol/Observable";
 import { setFeatureInfo } from "../../model/app/actions";
 import useIndexedFeatureInfo from "../../utils/useIndexedFeatureInfo";
 import useHighlightLayer from "../../utils/useHighlightLayer";
 import getPopupComponent from "../../utils/getPopupComponent";
 import "./FeatureInformation.scss";
+
+const useUpdateFeatureInfoOnLayerDeactivate = (layers, featureInfo) => {
+  const dispatch = useDispatch();
+  useEffect(() => {
+    const listeners = [];
+    layers.forEach((l) => {
+      const listener = l?.on("change:visible", (evt) => {
+        const layer = evt.target;
+        if (!layer.visible) {
+          layer.select();
+          layer.highlight();
+          dispatch(
+            setFeatureInfo(featureInfo.filter((info) => info.layer !== layer)),
+          );
+        }
+      });
+      listeners.push(listener);
+    });
+    return () => {
+      unByKey(listeners);
+    };
+  }, [layers, featureInfo, dispatch]);
+};
 
 function FeatureInformation({ featureInfo }) {
   const { t } = useTranslation();
@@ -26,6 +50,9 @@ function FeatureInformation({ featureInfo }) {
 
   // Hook to highlight map features
   useHighlightLayer(featureInfo, highlightLayer, featureIndex);
+
+  // Hook to filter out selected features for deactivated layers
+  useUpdateFeatureInfoOnLayerDeactivate(infoIndexed.layers.flat(), featureInfo);
 
   // The current feature(s) to display.
   const feature = infoIndexed.features[featureIndex];

--- a/src/utils/useUpdateFeatureInfoOnLayerToggle.js
+++ b/src/utils/useUpdateFeatureInfoOnLayerToggle.js
@@ -1,0 +1,33 @@
+import { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { unByKey } from "ol/Observable";
+
+import { setFeatureInfo } from "../model/app/actions";
+
+const useUpdateFeatureInfoOnLayerToggle = (layers) => {
+  const featureInfo = useSelector((state) => state.app.featureInfo);
+  const dispatch = useDispatch();
+  useEffect(() => {
+    const listeners = layers.map((l) => {
+      return l?.on("change:visible", (evt) => {
+        const layer = evt.target;
+        if (!layer.visible) {
+          if (layer?.select) {
+            layer.select();
+          }
+          if (layer?.highlight) {
+            layer.highlight();
+          }
+          dispatch(
+            setFeatureInfo(featureInfo.filter((info) => info.layer !== layer)),
+          );
+        }
+      });
+    });
+    return () => {
+      unByKey(listeners);
+    };
+  }, [layers, featureInfo, dispatch]);
+};
+
+export default useUpdateFeatureInfoOnLayerToggle;

--- a/src/utils/useUpdateFeatureInfoOnLayerToggle.test.js
+++ b/src/utils/useUpdateFeatureInfoOnLayerToggle.test.js
@@ -1,0 +1,55 @@
+import * as React from "react";
+import { render, act } from "@testing-library/react";
+import { Layer } from "mobility-toolbox-js/ol";
+import { Feature } from "ol";
+import { Provider } from "react-redux";
+import { ThemeProvider } from "@mui/material";
+
+import theme from "../themes/default";
+import useUpdateFeatureInfoOnLayerToggle from "./useUpdateFeatureInfoOnLayerToggle";
+
+const layer = new Layer({
+  visible: true,
+});
+const featureInfo = [
+  {
+    layer,
+    features: [new Feature()],
+    coordinate: [0, 0],
+  },
+];
+
+function TestComponent() {
+  useUpdateFeatureInfoOnLayerToggle([layer]);
+  return null;
+}
+
+describe("useUpdateFeatureInfoOnLayerToggle", () => {
+  let store;
+  beforeEach(() => {
+    store = global.mockStore({
+      app: {
+        featureInfo,
+      },
+    });
+  });
+  test("should remove featureInfo when layer is deactivated", () => {
+    const { unmount } = render(
+      <ThemeProvider theme={theme}>
+        <Provider store={store}>
+          <TestComponent />
+        </Provider>
+      </ThemeProvider>,
+    );
+    act(() => {
+      layer.visible = false;
+    });
+    expect(store.getActions()).toEqual([
+      {
+        type: "SET_FEATURE_INFO",
+        data: [],
+      },
+    ]);
+    unmount();
+  });
+});


### PR DESCRIPTION
# How to
When toggling layers the selected features in the overlay and the map should update accordingly. If features are removed from the map they need to be removed from the overlay as well.

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [ ] It's not a hack or at least an unauthorized hack :).
- [ ] The images added are optimized.
- [ ] Everything in ticket description has been fixed.
- [ ] The author of the MR has made its own review before assigning the reviewer.
- [ ] The title means something for a human being and follows the [conventional commits](https://www.conventionalcommits.org/) specification.
- [ ] The title contains [WIP] if it's necessary.
- [ ] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
