### PR TITLE
fix(Geltungsbereiche): adjusted line dash arrays for reduced fares in GB STS legend

### DIFF
--- a/src/config/ch.sbb.geltungsbereiche.mvp/index.js
+++ b/src/config/ch.sbb.geltungsbereiche.mvp/index.js
@@ -134,6 +134,8 @@ export const geltungsbereicheSTS = new GeltungsbereicheLayer({
       return "Freie Fahrt";
     },
     products: ["ch.sbb.geltungsbereiche.products.sts"],
+    lineDashArray50: [6, 8],
+    lineDashArray25: [6, 8, 1, 8, 1, 8],
   },
 });
 

--- a/src/popups/GeltungsbereicheGaPopup/GeltungsbereicheGaPopup.js
+++ b/src/popups/GeltungsbereicheGaPopup/GeltungsbereicheGaPopup.js
@@ -12,7 +12,7 @@ import {
   ListItemIcon,
 } from "@mui/material";
 import { FaCircle } from "react-icons/fa";
-import GeltungsbereicheLegend, { legends } from "./GeltungsbereicheLegend";
+import GeltungsbereicheLegend, { getLegends } from "./GeltungsbereicheLegend";
 import { infos } from "../../layerInfos/GeltungsbereicheLayerInfo/GeltungsbereicheLayerInfo";
 
 const propTypes = {
@@ -85,6 +85,9 @@ function GeltungsbereichePopup({
       }
       return text;
     });
+  const lineDashArray50 = layer.get("lineDashArray50");
+  const lineDashArray25 = layer.get("lineDashArray25");
+  const legends = getLegends(lineDashArray50, lineDashArray25);
 
   // Keep same mot order as in the legends
   const featuresByMot = {};
@@ -139,6 +142,8 @@ function GeltungsbereichePopup({
                   mot={feature.get("mot")}
                   valid={valid}
                   background
+                  lineDashArray50={lineDashArray50}
+                  lineDashArray25={lineDashArray25}
                 />
                 <div>
                   <Typography variant="h4">{t(`gb.mot.${mot}`)}</Typography>

--- a/src/popups/GeltungsbereicheGaPopup/GeltungsbereicheLegend.js
+++ b/src/popups/GeltungsbereicheGaPopup/GeltungsbereicheLegend.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-const dashArray = "1 7";
+export const defaultDashArray = [1, 7];
 const lineWidth = 3.5;
 const colorYellow = "rgba(255, 242, 0, 1)";
 const colorRed = "rgba(235, 0, 0, 1)";
@@ -10,195 +10,203 @@ const colorBlack = "rgba(0, 0, 0, 1)";
 const colorGray = "rgba(180,180,180, 1)";
 
 // Be aware that order is important here!
-export const legends = [
-  {
-    mots: ["rail", "tram", "subway"],
-    validity: [
-      {
-        value: 100,
-        paint: [
-          {
-            "line-color": colorRed,
-            "line-width": lineWidth,
-          },
-        ],
-      },
-      {
-        value: 50,
-        paint: [
-          {
-            "line-color": colorRed,
-            "line-width": lineWidth,
-            "line-dasharray": dashArray,
-          },
-        ],
-      },
-      {
-        value: 25,
-        paint: [
-          {
-            "line-color": colorRed,
-            "line-width": lineWidth,
-            "line-dasharray": dashArray,
-          },
-        ],
-      },
-    ],
-  },
-  {
-    mots: ["bus"],
-    validity: [
-      {
-        value: 100,
-        paint: [
-          {
-            "line-color": "rgba(74, 74, 74, 1)",
-            "line-width": lineWidth + 0.5,
-          },
-          {
-            "line-color": colorYellow,
-            "line-width": lineWidth,
-          },
-        ],
-      },
-      {
-        value: 50,
-        paint: [
-          {
-            "line-color": "rgba(74, 74, 74, 1)",
-            "line-width": lineWidth + 0.5,
-            "line-dasharray": dashArray,
-          },
-          {
-            "line-color": colorYellow,
-            "line-width": lineWidth,
-            "line-dasharray": dashArray,
-          },
-        ],
-      },
-      {
-        value: 25,
-        paint: [
-          {
-            "line-color": "rgba(74, 74, 74, 1)",
-            "line-width": lineWidth + 0.5,
-            "line-dasharray": dashArray,
-          },
-          {
-            "line-color": colorYellow,
-            "line-width": lineWidth,
-            "line-dasharray": dashArray,
-          },
-        ],
-      },
-    ],
-  },
-  {
-    mots: ["gondola", "funicular"],
-    validity: [
-      {
-        value: 100,
-        paint: [
-          {
-            "line-color": colorBlack,
-            "line-width": lineWidth,
-          },
-        ],
-      },
-      {
-        value: 50,
-        paint: [
-          {
-            "line-color": colorBlack,
-            "line-width": lineWidth,
-            "line-dasharray": dashArray,
-          },
-        ],
-      },
-      {
-        value: 25,
-        paint: [
-          {
-            "line-color": colorBlack,
-            "line-width": lineWidth,
-            "line-dasharray": dashArray,
-          },
-        ],
-      },
-    ],
-  },
-  {
-    mots: ["ferry"],
-    validity: [
-      {
-        value: 100,
-        paint: [
-          {
-            "line-color": colorBlue,
-            "line-width": lineWidth,
-          },
-        ],
-      },
-      {
-        value: 50,
-        paint: [
-          {
-            "line-color": colorBlue,
-            "line-width": lineWidth,
-            "line-dasharray": dashArray,
-          },
-        ],
-      },
-      {
-        value: 25,
-        paint: [
-          {
-            "line-color": colorBlue,
-            "line-width": lineWidth,
-            "line-dasharray": dashArray,
-          },
-        ],
-      },
-      {
-        value: -1,
-        paint: [
-          {
-            "line-color": colorGray,
-            "line-width": lineWidth,
-            "line-dasharray": dashArray,
-          },
-        ],
-      },
-    ],
-  },
-  {
-    mots: [null],
-    validity: [
-      {
-        value: null,
-        paint: [
-          {
-            "line-color": colorGray,
-            "line-width": lineWidth,
-          },
-        ],
-      },
-    ],
-  },
-];
+export const getLegends = (
+  lineDashArray50 = defaultDashArray,
+  lineDashArray25 = defaultDashArray,
+) => {
+  return [
+    {
+      mots: ["rail", "tram", "subway"],
+      validity: [
+        {
+          value: 100,
+          paint: [
+            {
+              "line-color": colorRed,
+              "line-width": lineWidth,
+            },
+          ],
+        },
+        {
+          value: 50,
+          paint: [
+            {
+              "line-color": colorRed,
+              "line-width": lineWidth,
+              "line-dasharray": lineDashArray50,
+            },
+          ],
+        },
+        {
+          value: 25,
+          paint: [
+            {
+              "line-color": colorRed,
+              "line-width": lineWidth,
+              "line-dasharray": lineDashArray25,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      mots: ["bus"],
+      validity: [
+        {
+          value: 100,
+          paint: [
+            {
+              "line-color": "rgba(74, 74, 74, 1)",
+              "line-width": lineWidth + 0.5,
+            },
+            {
+              "line-color": colorYellow,
+              "line-width": lineWidth,
+            },
+          ],
+        },
+        {
+          value: 50,
+          paint: [
+            {
+              "line-color": "rgba(74, 74, 74, 1)",
+              "line-width": lineWidth + 0.5,
+              "line-dasharray": lineDashArray50,
+            },
+            {
+              "line-color": colorYellow,
+              "line-width": lineWidth,
+              "line-dasharray": lineDashArray50,
+            },
+          ],
+        },
+        {
+          value: 25,
+          paint: [
+            {
+              "line-color": "rgba(74, 74, 74, 1)",
+              "line-width": lineWidth + 0.5,
+              "line-dasharray": lineDashArray25,
+            },
+            {
+              "line-color": colorYellow,
+              "line-width": lineWidth,
+              "line-dasharray": lineDashArray25,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      mots: ["gondola", "funicular"],
+      validity: [
+        {
+          value: 100,
+          paint: [
+            {
+              "line-color": colorBlack,
+              "line-width": lineWidth,
+            },
+          ],
+        },
+        {
+          value: 50,
+          paint: [
+            {
+              "line-color": colorBlack,
+              "line-width": lineWidth,
+              "line-dasharray": lineDashArray50,
+            },
+          ],
+        },
+        {
+          value: 25,
+          paint: [
+            {
+              "line-color": colorBlack,
+              "line-width": lineWidth,
+              "line-dasharray": lineDashArray25,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      mots: ["ferry"],
+      validity: [
+        {
+          value: 100,
+          paint: [
+            {
+              "line-color": colorBlue,
+              "line-width": lineWidth,
+            },
+          ],
+        },
+        {
+          value: 50,
+          paint: [
+            {
+              "line-color": colorBlue,
+              "line-width": lineWidth,
+              "line-dasharray": lineDashArray50,
+            },
+          ],
+        },
+        {
+          value: 25,
+          paint: [
+            {
+              "line-color": colorBlue,
+              "line-width": lineWidth,
+              "line-dasharray": lineDashArray25,
+            },
+          ],
+        },
+        {
+          value: -1,
+          paint: [
+            {
+              "line-color": colorGray,
+              "line-width": lineWidth,
+              "line-dasharray": defaultDashArray,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      mots: [null],
+      validity: [
+        {
+          value: null,
+          paint: [
+            {
+              "line-color": colorGray,
+              "line-width": lineWidth,
+            },
+          ],
+        },
+      ],
+    },
+  ];
+};
 
 // eslint-disable-next-line react/prop-types
-function GeltungsbereicheLegend({ mot, valid, background }) {
-  const legend = legends
+function GeltungsbereicheLegend({
+  mot,
+  valid,
+  background,
+  lineDashArray50,
+  lineDashArray25,
+}) {
+  const legend = getLegends(lineDashArray50, lineDashArray25)
     .find(({ mots }) => {
       return mots.includes(mot);
     })
     ?.validity.find(({ value }) => {
       if (Array.isArray(value) && !Array.isArray(valid)) {
         return value.includes(valid);
-      }
-      if (Array.isArray(value) && !Array.isArray(valid)) {
-        return value.toString() === valid.toString();
       }
       return value === valid;
     });
@@ -228,7 +236,7 @@ function GeltungsbereicheLegend({ mot, valid, background }) {
             y2={background ? "25" : "5"}
             stroke={paint["line-color"]}
             strokeWidth={paint["line-width"]}
-            strokeDasharray={paint["line-dasharray"]}
+            strokeDasharray={paint["line-dasharray"]?.join(" ")}
             strokeLinecap={paint["line-dasharray"] && "round"}
           />
         );
@@ -241,12 +249,16 @@ GeltungsbereicheLegend.propTypes = {
   mot: PropTypes.string,
   valid: PropTypes.number,
   background: PropTypes.bool,
+  lineDashArray50: PropTypes.arrayOf(PropTypes.number),
+  lineDashArray25: PropTypes.arrayOf(PropTypes.number),
 };
 
 GeltungsbereicheLegend.defaultProps = {
   mot: null,
   valid: null,
   background: false,
+  lineDashArray50: [1, 7],
+  lineDashArray25: [1, 7],
 };
 
 export default GeltungsbereicheLegend;

--- a/src/popups/GeltungsbereicheGaPopup/GeltungsbereicheLegend.test.js
+++ b/src/popups/GeltungsbereicheGaPopup/GeltungsbereicheLegend.test.js
@@ -1,13 +1,9 @@
-import { legends } from "./GeltungsbereicheLegend";
+import { getLegends } from "./GeltungsbereicheLegend";
 
 describe("GeltungsbereicheLegend", () => {
   test("exports legends that have the good mots order", () => {
-    expect(Object.values(legends).map(({ mots }) => mots && mots[0])).toEqual([
-      "rail",
-      "bus",
-      "gondola",
-      "ferry",
-      null,
-    ]);
+    expect(
+      Object.values(getLegends()).map(({ mots }) => mots && mots[0]),
+    ).toEqual(["rail", "bus", "gondola", "ferry", null]);
   });
 });


### PR DESCRIPTION
# How to
The legend for reduced fares in STS Geltungsbereiche layer did not reflect the line dash array on the map.
Fix: The line dash array has been made configurable on on layer level.

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [ ] It's not a hack or at least an unauthorized hack :).
- [ ] The images added are optimized.
- [ ] Everything in ticket description has been fixed.
- [ ] The author of the MR has made its own review before assigning the reviewer.
- [ ] The title means something for a human being and follows the [conventional commits](https://www.conventionalcommits.org/) specification.
- [ ] The title contains [WIP] if it's necessary.
- [ ] Labels applied. if it's a release? a hotfix?
- [ ] Tests added.
