### PR TITLE
fix: use good color for cancelled trains on low zoom level

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "jspdf": "2.5.1",
     "mapbox-gl": "1.13.3",
     "maplibre-gl": "4.5.1",
-    "mobility-toolbox-js": "2.4.2",
+    "mobility-toolbox-js": "2.4.3",
     "ol": "9.2.4",
     "proj4": "2.12.0",
     "prop-types": "15.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11427,10 +11427,10 @@ mkdirp@^1.0.3:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-mobility-toolbox-js@2.4.2:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/mobility-toolbox-js/-/mobility-toolbox-js-2.4.2.tgz#5e30a77ce7ce12f64cf18f1ff9db948121f5c9ea"
-  integrity sha512-ff1bZdH6lPaY7oa2/tEq+IkLhek/VKgGiMbBwJbAA3G+FQHlgwvDyKCYI87pCns7LNZFpWpVeR+tdlg6q6HgWw==
+mobility-toolbox-js@2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/mobility-toolbox-js/-/mobility-toolbox-js-2.4.3.tgz#f416fcb32efea4eba4db291f75dc6bd68dd9b830"
+  integrity sha512-rao7tCqWC2I8TKxjTR2SSwzW4OZ/4+oVZkVXZp6nsOv2iTeW5ktr5jhMcEf61QXq0U4j3G34b9QKL7DaeGHjhw==
   dependencies:
     "@turf/helpers" "6.5.0"
     "@turf/transform-rotate" "6.5.0"


### PR DESCRIPTION
# How to

<!--  Please provide a test link and quick description how to see the change -->

Cancelled trains are displayed in gray instead of green on low zoom level (small points)

# Others

<!-- Thanks for the PR! Feel free to add or remove items if there are not necessary. -->

- [x] It's not a hack or at least an unauthorized hack :).
- [x] The images added are optimized.
- [x] Everything in ticket description has been fixed.
- [x] The author of the MR has made its own review before assigning the reviewer.
- [x] The title means something for a human being and follows the [conventional commits](https://www.conventionalcommits.org/) specification.
- [x] The title contains [WIP] if it's necessary.
- [x] Labels applied. if it's a release? a hotfix?
- [x] Tests added.
